### PR TITLE
Rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ multid-static
 trace.*
 *.log
 *problem_3D_100.npy
+D/multigrid_old

--- a/D/GSRBBenchmark.d
+++ b/D/GSRBBenchmark.d
@@ -20,7 +20,7 @@ void main(string[] argv)
     void warmup()
     {
         auto UF1 = npyload!(double, 2)(i.default_path);
-        GS_RB!(SweepType.field)(UF1[1].slice, UF1[0].slice, 1, iterations, iterations + 10, 1e-8);
+        GS_RB!(SweepType.ndslice)(UF1[1].slice, UF1[0].slice, 1, iterations, iterations + 10, 1e-8);
     }
 
     const uint dim = getDim(i.path);
@@ -37,8 +37,11 @@ void main(string[] argv)
     case "naive":
         GS_RB!(SweepType.naive)(UF[1].slice, UF[0].slice, 1, iterations, iterations + 10, 1e-8);
         break;
-    default:
+    case "field":
         GS_RB!(SweepType.field)(UF[1].slice, UF[0].slice, 1, iterations, iterations + 10, 1e-8);
+        break;
+    default:
+        GS_RB!(SweepType.ndslice)(UF[1].slice, UF[0].slice, 1, iterations, iterations + 10, 1e-8);
 
     }
     i.print_time();

--- a/D/GSRBBenchmark.d
+++ b/D/GSRBBenchmark.d
@@ -20,7 +20,7 @@ void main(string[] argv)
     void warmup()
     {
         auto UF1 = npyload!(double, 2)(i.default_path);
-        GS_RB!(iterations, iterations + 10, 1e-8, SweepType.field)(UF1[1].slice, UF1[0].slice, 1);
+        GS_RB!(SweepType.field)(UF1[1].slice, UF1[0].slice, 1, iterations, iterations + 10, 1e-8);
     }
 
     const uint dim = getDim(i.path);
@@ -32,13 +32,13 @@ void main(string[] argv)
     switch (i.sweep)
     {
     case "slice":
-        GS_RB!(iterations, iterations + 10, 1e-8, SweepType.slice)(UF[1].slice, UF[0].slice, 1);
+        GS_RB!(SweepType.slice)(UF[1].slice, UF[0].slice, 1, iterations, iterations + 10, 1e-8);
         break;
     case "naive":
-        GS_RB!(iterations, iterations + 10, 1e-8, SweepType.naive)(UF[1].slice, UF[0].slice, 1);
+        GS_RB!(SweepType.naive)(UF[1].slice, UF[0].slice, 1, iterations, iterations + 10, 1e-8);
         break;
     default:
-        GS_RB!(iterations, iterations + 10, 1e-8, SweepType.field)(UF[1].slice, UF[0].slice, 1);
+        GS_RB!(SweepType.field)(UF[1].slice, UF[0].slice, 1, iterations, iterations + 10, 1e-8);
 
     }
     i.print_time();

--- a/D/GSRBBenchmark.d
+++ b/D/GSRBBenchmark.d
@@ -20,7 +20,7 @@ void main(string[] argv)
     void warmup()
     {
         auto UF1 = npyload!(double, 2)(i.default_path);
-        GS_RB!(double, 2, iterations, iterations + 10, 1e-8, SweepType.field)(UF1[1].slice, UF1[0].slice, 1);
+        GS_RB!(iterations, iterations + 10, 1e-8, SweepType.field)(UF1[1].slice, UF1[0].slice, 1);
     }
 
     const uint dim = getDim(i.path);
@@ -32,13 +32,13 @@ void main(string[] argv)
     switch (i.sweep)
     {
     case "slice":
-        GS_RB!(double, 2, iterations, iterations + 10, 1e-8, SweepType.slice)(UF[1].slice, UF[0].slice, 1);
+        GS_RB!(iterations, iterations + 10, 1e-8, SweepType.slice)(UF[1].slice, UF[0].slice, 1);
         break;
     case "naive":
-        GS_RB!(double, 2, iterations, iterations + 10, 1e-8, SweepType.naive)(UF[1].slice, UF[0].slice, 1);
+        GS_RB!(iterations, iterations + 10, 1e-8, SweepType.naive)(UF[1].slice, UF[0].slice, 1);
         break;
     default:
-        GS_RB!(double, 2, iterations, iterations + 10, 1e-8, SweepType.field)(UF[1].slice, UF[0].slice, 1);
+        GS_RB!(iterations, iterations + 10, 1e-8, SweepType.field)(UF[1].slice, UF[0].slice, 1);
 
     }
     i.print_time();

--- a/D/app.d
+++ b/D/app.d
@@ -19,7 +19,7 @@ void main(string[] argv)
     void warmup()
     {
         auto UF1 = npyload!(double, 2)(i.default_path);
-        poisson_multigrid!(double, 2, 2, 2)(UF1[1].slice, UF1[0].slice, 0, 1, 1);
+        poisson_multigrid!(2, 2)(UF1[1].slice, UF1[0].slice, 0, 1, 1);
     }
 
     const uint dim = getDim(i.path);
@@ -30,19 +30,19 @@ void main(string[] argv)
         auto UF = npyload!(double, 1)(i.path);
         warmup();
         i.wait_till();
-        poisson_multigrid!(double, 1, 2, 2)(UF[1].slice, UF[0].slice, 0, 1, 100, i.sweep);
+        poisson_multigrid!(2, 2)(UF[1].slice, UF[0].slice, 0, 1, 100, i.sweep);
         break;
     case 2:
         auto UF = npyload!(double, 2)(i.path);
         warmup();
         i.wait_till();
-        poisson_multigrid!(double, 2, 2, 2)(UF[1].slice, UF[0].slice, 0, 1, 100, i.sweep);
+        poisson_multigrid!(2, 2)(UF[1].slice, UF[0].slice, 0, 1, 100, i.sweep);
         break;
     case 3:
         auto UF = npyload!(double, 3)(i.path);
         warmup();
         i.wait_till();
-        poisson_multigrid!(double, 3, 2, 2)(UF[1].slice, UF[0].slice, 0, 1, 100, i.sweep);
+        poisson_multigrid!(2, 2)(UF[1].slice, UF[0].slice, 0, 1, 100, i.sweep);
         break;
     default:
         throw new Exception("wrong dimension!");

--- a/D/app.d
+++ b/D/app.d
@@ -19,7 +19,7 @@ void main(string[] argv)
     void warmup()
     {
         auto UF1 = npyload!(double, 2)(i.default_path);
-        poisson_multigrid!(2, 2)(UF1[1].slice, UF1[0].slice, 0, 1, 1);
+        poisson_multigrid(UF1[1].slice, UF1[0].slice, 0, 1, 2, 2, 1);
     }
 
     const uint dim = getDim(i.path);
@@ -30,19 +30,19 @@ void main(string[] argv)
         auto UF = npyload!(double, 1)(i.path);
         warmup();
         i.wait_till();
-        poisson_multigrid!(2, 2)(UF[1].slice, UF[0].slice, 0, 1, 100, i.sweep);
+        poisson_multigrid(UF[1].slice, UF[0].slice, 0, 1, 2, 2, 100, i.sweep);
         break;
     case 2:
         auto UF = npyload!(double, 2)(i.path);
         warmup();
         i.wait_till();
-        poisson_multigrid!(2, 2)(UF[1].slice, UF[0].slice, 0, 1, 100, i.sweep);
+        poisson_multigrid(UF[1].slice, UF[0].slice, 0, 1, 2, 2, 100, i.sweep);
         break;
     case 3:
         auto UF = npyload!(double, 3)(i.path);
         warmup();
         i.wait_till();
-        poisson_multigrid!(2, 2)(UF[1].slice, UF[0].slice, 0, 1, 100, i.sweep);
+        poisson_multigrid(UF[1].slice, UF[0].slice, 0, 1, 2, 2, 100, i.sweep);
         break;
     default:
         throw new Exception("wrong dimension!");

--- a/D/dub.json
+++ b/D/dub.json
@@ -2,7 +2,7 @@
   "name": "multid",
 
   "dependencies": {
-    "mir-algorithm": "~>3.10.9",
+    "mir-algorithm": "~>3.10.10",
     "mir-random": "~>2.2.14",
     "numir": "~>2.0.5"
   },

--- a/D/dub.json
+++ b/D/dub.json
@@ -2,7 +2,7 @@
   "name": "multid",
 
   "dependencies": {
-    "mir-algorithm": "~>3.10.10",
+    "mir-algorithm": "~>3.10.11",
     "mir-random": "~>2.2.14",
     "numir": "~>2.0.5"
   },

--- a/D/dub.json
+++ b/D/dub.json
@@ -2,7 +2,7 @@
   "name": "multid",
 
   "dependencies": {
-    "mir-algorithm": "~>3.10.6",
+    "mir-algorithm": "~>3.10.9",
     "mir-random": "~>2.2.14",
     "numir": "~>2.0.5"
   },

--- a/D/dub.json
+++ b/D/dub.json
@@ -2,10 +2,9 @@
   "name": "multid",
 
   "dependencies": {
-    "mir-algorithm": "~>3.9.6",
+    "mir-algorithm": "~>3.10.4",
     "mir-random": "~>2.2.14",
-    "numir": "~>2.0.5",
-    "pretty_array": "~>1.0.2"
+    "numir": "~>2.0.5"
   },
   "configurations": [
     {
@@ -13,7 +12,7 @@
       "targetName": "multigrid",
       "mainSourceFile": "app.d",
       "compiler": "ldc",
-      "dflags-ldc": ["-mcpu=native", "--boundscheck=off"],
+      "dflags-ldc": ["-mcpu=native"],
       "targetType": "executable"
     },
     {
@@ -22,13 +21,13 @@
       "targetType": "executable",
       "targetName": "multid-static",
       "compiler": "ldc",
-      "dflags-ldc": ["--static"]
+      "dflags-ldc": ["-mcpu=native", "--static"]
     },
     {
       "name": "gsrb",
       "mainSourceFile": "GSRBBenchmark.d",
       "targetName": "gsrb",
-      "dflags-ldc": ["-mcpu=native", "--boundscheck=off"],
+      "dflags-ldc": ["-mcpu=native"],
       "targetType": "executable",
       "compiler": "ldc"
     }

--- a/D/dub.json
+++ b/D/dub.json
@@ -2,7 +2,7 @@
   "name": "multid",
 
   "dependencies": {
-    "mir-algorithm": "~>3.10.4",
+    "mir-algorithm": "~>3.10.6",
     "mir-random": "~>2.2.14",
     "numir": "~>2.0.5"
   },

--- a/D/source/loadproblem.d
+++ b/D/source/loadproblem.d
@@ -1,10 +1,10 @@
 module loadproblem;
 
+import mir.conv : to;
 import mir.ndslice;
 import numir.io;
 import std.regex;
 import std.stdio;
-import std.conv : to;
 
 // /++
 // Implementation of npy loader

--- a/D/source/multid/gaussseidel/redblack.d
+++ b/D/source/multid/gaussseidel/redblack.d
@@ -85,9 +85,9 @@ size_t GS_RB(SweepType sweeptype = SweepType.ndslice, T, size_t Dim)(
 
         }
         // rote Halbiteration
-        sweep!(Chequer.red)(F, U, h2);
+        sweep(Chequer.red, F, U, h2);
         // schwarze Halbiteration
-        sweep!(Chequer.black)(F, U, h2);
+        sweep(Chequer.black, F, U, h2);
     }
     return it;
 }
@@ -136,18 +136,18 @@ unittest
     auto U3 = U.dup;
     const F = slice!double([N], 1.0);
 
-    sweep_naive!(Chequer.red)(F, U, h2);
-    sweep_field!(Chequer.red)(F, U1, h2);
-    sweep_slice!(Chequer.red)(F, U2, h2);
-    sweep_ndslice!(Chequer.red)(F, U3, h2);
+    sweep_naive(Chequer.red, F, U, h2);
+    sweep_field(Chequer.red, F, U1, h2);
+    sweep_slice(Chequer.red, F, U2, h2);
+    sweep_ndslice(Chequer.red, F, U3, h2);
     assert(U == U1);
     assert(U1 == U2);
     assert(all!approxEqual(U, U3));
 
-    sweep_naive!(Chequer.black)(F, U, h2);
-    sweep_field!(Chequer.black)(F, U1, h2);
-    sweep_slice!(Chequer.black)(F, U2, h2);
-    sweep_ndslice!(Chequer.black)(F, U3, h2);
+    sweep_naive(Chequer.black, F, U, h2);
+    sweep_field(Chequer.black, F, U1, h2);
+    sweep_slice(Chequer.black, F, U2, h2);
+    sweep_ndslice(Chequer.black, F, U3, h2);
     assert(U == U1);
     assert(U1 == U2);
     assert(all!approxEqual(U, U3));
@@ -168,18 +168,18 @@ unittest
     auto U3 = U.dup;
     const F = slice!double([N, N], 1.0);
 
-    sweep_naive!(Chequer.red)(F, U, h2);
-    sweep_field!(Chequer.red)(F, U1, h2);
-    sweep_slice!(Chequer.red)(F, U2, h2);
-    sweep_ndslice!(Chequer.red)(F, U3, h2);
+    sweep_naive(Chequer.red, F, U, h2);
+    sweep_field(Chequer.red, F, U1, h2);
+    sweep_slice(Chequer.red, F, U2, h2);
+    sweep_ndslice(Chequer.red, F, U3, h2);
     assert(U == U1);
     assert(U1 == U2);
     assert(all!approxEqual(U, U3));
 
-    sweep_naive!(Chequer.black)(F, U, h2);
-    sweep_field!(Chequer.black)(F, U1, h2);
-    sweep_slice!(Chequer.black)(F, U2, h2);
-    sweep_ndslice!(Chequer.black)(F, U3, h2);
+    sweep_naive(Chequer.black, F, U, h2);
+    sweep_field(Chequer.black, F, U1, h2);
+    sweep_slice(Chequer.black, F, U2, h2);
+    sweep_ndslice(Chequer.black, F, U3, h2);
     assert(U == U1);
     assert(U1 == U2);
     assert(all!approxEqual(U, U3));
@@ -198,20 +198,20 @@ unittest
     const F = slice!double([N, N, N], 1.0);
     const double h2 = 1.0;
 
-    sweep_naive!(Chequer.red)(F, U, h2);
-    sweep_field!(Chequer.red)(F, U1, h2);
-    sweep_slice!(Chequer.red)(F, U2, h2);
-    sweep_ndslice!(Chequer.red)(F, U3, h2);
+    sweep_naive(Chequer.red, F, U, h2);
+    sweep_field(Chequer.red, F, U1, h2);
+    sweep_slice(Chequer.red, F, U2, h2);
+    sweep_ndslice(Chequer.red, F, U3, h2);
     // import std.stdio;
     // writeln(U - U1);
     assert(U == U1);
     assert(U1 == U2);
     assert(all!approxEqual(U, U3));
 
-    sweep_naive!(Chequer.black)(F, U, h2);
-    sweep_field!(Chequer.black)(F, U1, h2);
-    sweep_slice!(Chequer.black)(F, U2, h2);
-    sweep_ndslice!(Chequer.black)(F, U3, h2);
+    sweep_naive(Chequer.black, F, U, h2);
+    sweep_field(Chequer.black, F, U1, h2);
+    sweep_slice(Chequer.black, F, U2, h2);
+    sweep_ndslice(Chequer.black, F, U3, h2);
     assert(U == U1);
     assert(U1 == U2);
     assert(all!approxEqual(U, U3));

--- a/D/source/multid/gaussseidel/redblack.d
+++ b/D/source/multid/gaussseidel/redblack.d
@@ -76,6 +76,7 @@ size_t GS_RB(size_t max_iter = 10_000_000, size_t norm_iter = 1_000,
     while (it < max_iter)
     {
         it++;
+        static if (norm_iter < max_iter)
         if (it % norm_iter == 0)
         {
             compute_residual(R, F, U, h);

--- a/D/source/multid/gaussseidel/redblack.d
+++ b/D/source/multid/gaussseidel/redblack.d
@@ -36,7 +36,7 @@ Params:
 Returns: U
 +/
 
-Slice!(T*, Dim) GS_RB(SweepType sweeptype = SweepType.field, T, size_t Dim)(
+Slice!(T*, Dim) GS_RB(SweepType sweeptype = SweepType.ndslice, T, size_t Dim)(
     Slice!(const(T)*, Dim) F,
     Slice!(T*, Dim) U,
     const T h,
@@ -44,7 +44,7 @@ Slice!(T*, Dim) GS_RB(SweepType sweeptype = SweepType.field, T, size_t Dim)(
     size_t norm_iter = 1_000,
     double eps = 1e-8,
     )
-if (1 <= Dim && Dim <= 3 && isFloatingPoint!T)
+    if ((1 <= Dim && Dim <= 8) && isFloatingPoint!T)
 {
     auto R = U.shape.slice!T;
     T norm;
@@ -54,7 +54,7 @@ if (1 <= Dim && Dim <= 3 && isFloatingPoint!T)
 }
 
 @nogc @fastmath
-size_t GS_RB(SweepType sweeptype = SweepType.field, T, size_t Dim)(
+size_t GS_RB(SweepType sweeptype = SweepType.ndslice, T, size_t Dim)(
     Slice!(const(T)*, Dim) F,
     Slice!(T*, Dim) U,
     Slice!(T*, Dim) R, //residual
@@ -64,7 +64,7 @@ size_t GS_RB(SweepType sweeptype = SweepType.field, T, size_t Dim)(
     size_t norm_iter = 1_000,
     double eps = 1e-8,
     )
-    if (1 <= Dim && Dim <= 3 && isFloatingPoint!T)
+    if ((1 <= Dim && Dim <= 8) && isFloatingPoint!T)
 {
     mixin("alias sweep = sweep_" ~ sweeptype ~ ";");
 

--- a/D/source/multid/gaussseidel/redblack.d
+++ b/D/source/multid/gaussseidel/redblack.d
@@ -136,7 +136,7 @@ unittest
     auto U = randomMatrix!(double, 1)(N);
     auto U1 = U.dup;
     auto U2 = U.dup;
-    const auto F = slice!double([N], 1.0);
+    const F = slice!double([N], 1.0);
 
     sweep_naive!(Color.red)(F, U, h2);
     sweep_field!(Color.red)(F, U1, h2);
@@ -163,7 +163,7 @@ unittest
     auto U = randomMatrix!(double, 2)(N);
     auto U1 = U.dup;
     auto U2 = U.dup;
-    const auto F = slice!double([N, N], 1.0);
+    const F = slice!double([N, N], 1.0);
 
     sweep_naive!(Color.red)(F, U, h2);
     sweep_field!(Color.red)(F, U1, h2);
@@ -187,7 +187,7 @@ unittest
     auto U = randomMatrix!(double, 3)(N);
     auto U1 = U.dup;
     auto U2 = U.dup;
-    const auto F = slice!double([N, N, N], 1.0);
+    const F = slice!double([N, N, N], 1.0);
     const double h2 = 1.0;
 
     sweep_naive!(Color.red)(F, U, h2);

--- a/D/source/multid/gaussseidel/redblack.d
+++ b/D/source/multid/gaussseidel/redblack.d
@@ -1,6 +1,7 @@
 module multid.gaussseidel.redblack;
 
-import mir.math: fastmath;
+import mir.math: fastmath, approxEqual;
+import mir.algorithm.iteration: Chequer, all;
 import mir.ndslice : slice, uninitSlice, sliced, Slice, strided;
 import multid.gaussseidel.sweep;
 import multid.tools.apply_poisson : compute_residual;
@@ -8,19 +9,10 @@ import multid.tools.norm : nrmL2;
 import std.experimental.logger;
 import std.traits : isFloatingPoint;
 
-/++
-    red is for even indicies
-    black for the odd
-+/
-enum Color
-{
-    red = 1u,
-    black = 0u
-}
-
 /++ enum to differentiate between sweep types +/
 enum SweepType
 {
+    ndslice = "ndslice",
     field = "field",
     slice = "slice",
     naive = "naive"
@@ -93,9 +85,9 @@ size_t GS_RB(SweepType sweeptype = SweepType.field, T, size_t Dim)(
 
         }
         // rote Halbiteration
-        sweep!(Color.red)(F, U, h2);
+        sweep!(Chequer.red)(F, U, h2);
         // schwarze Halbiteration
-        sweep!(Color.black)(F, U, h2);
+        sweep!(Chequer.black)(F, U, h2);
     }
     return it;
 }
@@ -141,19 +133,24 @@ unittest
     auto U = randomMatrix!(double, 1)(N);
     auto U1 = U.dup;
     auto U2 = U.dup;
+    auto U3 = U.dup;
     const F = slice!double([N], 1.0);
 
-    sweep_naive!(Color.red)(F, U, h2);
-    sweep_field!(Color.red)(F, U1, h2);
-    sweep_slice!(Color.red)(F, U2, h2);
+    sweep_naive!(Chequer.red)(F, U, h2);
+    sweep_field!(Chequer.red)(F, U1, h2);
+    sweep_slice!(Chequer.red)(F, U2, h2);
+    sweep_ndslice!(Chequer.red)(F, U3, h2);
     assert(U == U1);
     assert(U1 == U2);
+    assert(all!approxEqual(U, U3));
 
-    sweep_naive!(Color.black)(F, U, h2);
-    sweep_field!(Color.black)(F, U1, h2);
-    sweep_slice!(Color.black)(F, U2, h2);
+    sweep_naive!(Chequer.black)(F, U, h2);
+    sweep_field!(Chequer.black)(F, U1, h2);
+    sweep_slice!(Chequer.black)(F, U2, h2);
+    sweep_ndslice!(Chequer.black)(F, U3, h2);
     assert(U == U1);
     assert(U1 == U2);
+    assert(all!approxEqual(U, U3));
 
 }
 
@@ -168,19 +165,24 @@ unittest
     auto U = randomMatrix!(double, 2)(N);
     auto U1 = U.dup;
     auto U2 = U.dup;
+    auto U3 = U.dup;
     const F = slice!double([N, N], 1.0);
 
-    sweep_naive!(Color.red)(F, U, h2);
-    sweep_field!(Color.red)(F, U1, h2);
-    sweep_slice!(Color.red)(F, U2, h2);
+    sweep_naive!(Chequer.red)(F, U, h2);
+    sweep_field!(Chequer.red)(F, U1, h2);
+    sweep_slice!(Chequer.red)(F, U2, h2);
+    sweep_ndslice!(Chequer.red)(F, U3, h2);
     assert(U == U1);
     assert(U1 == U2);
+    assert(all!approxEqual(U, U3));
 
-    sweep_naive!(Color.black)(F, U, h2);
-    sweep_field!(Color.black)(F, U1, h2);
-    sweep_slice!(Color.black)(F, U2, h2);
+    sweep_naive!(Chequer.black)(F, U, h2);
+    sweep_field!(Chequer.black)(F, U1, h2);
+    sweep_slice!(Chequer.black)(F, U2, h2);
+    sweep_ndslice!(Chequer.black)(F, U3, h2);
     assert(U == U1);
     assert(U1 == U2);
+    assert(all!approxEqual(U, U3));
 }
 
 unittest
@@ -192,20 +194,25 @@ unittest
     auto U = randomMatrix!(double, 3)(N);
     auto U1 = U.dup;
     auto U2 = U.dup;
+    auto U3 = U.dup;
     const F = slice!double([N, N, N], 1.0);
     const double h2 = 1.0;
 
-    sweep_naive!(Color.red)(F, U, h2);
-    sweep_field!(Color.red)(F, U1, h2);
-    sweep_slice!(Color.red)(F, U2, h2);
+    sweep_naive!(Chequer.red)(F, U, h2);
+    sweep_field!(Chequer.red)(F, U1, h2);
+    sweep_slice!(Chequer.red)(F, U2, h2);
+    sweep_ndslice!(Chequer.red)(F, U3, h2);
     // import std.stdio;
     // writeln(U - U1);
     assert(U == U1);
     assert(U1 == U2);
+    assert(all!approxEqual(U, U3));
 
-    sweep_naive!(Color.black)(F, U, h2);
-    sweep_field!(Color.black)(F, U1, h2);
-    sweep_slice!(Color.black)(F, U2, h2);
+    sweep_naive!(Chequer.black)(F, U, h2);
+    sweep_field!(Chequer.black)(F, U1, h2);
+    sweep_slice!(Chequer.black)(F, U2, h2);
+    sweep_ndslice!(Chequer.black)(F, U3, h2);
     assert(U == U1);
     assert(U1 == U2);
+    assert(all!approxEqual(U, U3));
 }

--- a/D/source/multid/gaussseidel/sweep.d
+++ b/D/source/multid/gaussseidel/sweep.d
@@ -43,13 +43,12 @@ Params:
 @nogc @fastmath
 void sweep_field(Chequer color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const T h2) nothrow
 {
-    assumeSameShape(F, U);
     const N = F.shape[0];
     auto UF = U.field;
     auto FF = F.field;
     for (size_t i = 2u - color; i < N - 1u; i += 2u)
     {
-        UF[i] = (UF[i - 1u] + UF[i + 1u] - FF[i] * h2) * (T(1) /  2);
+        UF[i] = (UF[i - 1u] + UF[i + 1u] - FF[i] * h2) / 2;
     }
 }
 
@@ -80,7 +79,7 @@ void sweep_field(Chequer color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, cons
                     UF[flatindex - m] +
                     UF[flatindex + m] +
                     UF[flatindex - 1] +
-                    UF[flatindex + 1] - h2 * FF[flatindex]) * (T(1) / 4);
+                    UF[flatindex + 1] - h2 * FF[flatindex]) / 4;
         }
     }
 }
@@ -233,55 +232,33 @@ void sweep_slice(Chequer color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, cons
 @nogc @fastmath
 void sweep_naive(Chequer color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const T h2) nothrow
 {
-
-    const n = F.shape[0];
-    foreach (i; 1 .. n - 1)
-    {
+    foreach (i; 1 .. F.length - 1)
         if (i % 2 == color)
-        {
-            U[i] = (U[i - 1u] + U[i + 1u] - F[i] * h2) * (T(1) /  2);
-        }
-    }
-
+            U[i] = (U[i - 1u] + U[i + 1u] - F[i] * h2) / 2;
 }
 /++ naive sweep for 2D +/
 @nogc @fastmath
 void sweep_naive(Chequer color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const T h2) nothrow
 {
-    const n = F.shape[0];
-    const m = F.shape[1];
-
-    foreach (i; 1 .. n - 1)
-    {
-        foreach (j; 1 .. m - 1)
-        {
-            if ((i + j) % 2 == color)
-            {
-                U[i, j] = (U[i - 1, j] + U[i + 1, j] + U[i, j - 1] + U[i, j + 1] - h2 * F[i, j]) * (T(1) / 4);
-            }
-        }
-    }
+    foreach (i; 1 .. F.length!0 - 1)
+    foreach (j; 1 .. F.length!1 - 1)
+        if ((i + j) % 2 == color)
+            U[i, j] = (U[i - 1, j] + U[i + 1, j] + U[i, j - 1] + U[i, j + 1] - h2 * F[i, j]) / 4;
 }
 /++ naive sweep for 3D +/
 @nogc @fastmath
 void sweep_naive(Chequer color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const T h2) nothrow
 {
-    const n = F.shape[0];
-    const m = F.shape[1];
-    const l = F.shape[2];
-    for (size_t i = 1u; i < n - 1u; i++)
-    {
-        for (size_t j = 1u; j < m - 1u; j++)
-        {
-            for (size_t k = 1u; k < l - 1u; k++)
-            {
-                if ((i + j + k) % 2 == color)
-                {
-                    U[i, j, k] = (U[i - 1, j, k] + U[i + 1, j, k] + U[i, j - 1,
-                            k] + U[i, j + 1, k] + U[i, j, k - 1] + U[i, j, k + 1] - h2 * F[i, j, k]) * (T(1) / 6);
-                }
-            }
-        }
-    }
+    foreach (i; 1 .. F.length!0 - 1)
+    foreach (j; 1 .. F.length!1 - 1)
+    foreach (k; 1 .. F.length!2 - 1)
+        if ((i + j + k) % 2 == color)
+            U[i, j, k] = (T(1) / 6) *
+                (U[i - 1, j, k]
+                + U[i + 1, j, k]
+                + U[i, j - 1, k]
+                + U[i, j + 1, k]
+                + U[i, j, k - 1]
+                + U[i, j, k + 1]
+                - h2 * F[i, j, k]);
 }
-

--- a/D/source/multid/gaussseidel/sweep.d
+++ b/D/source/multid/gaussseidel/sweep.d
@@ -95,14 +95,6 @@ void sweep_field(Color color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const 
     }
 }
 
-// TODO: add to Mir
-@fastmath auto strideAll(T, size_t Dim, SliceKind kind)(Slice!(T*, Dim, kind) slice, size_t factor)
-{
-    import mir.internal.utility: Iota;
-    import std.meta: Repeat;
-    return slice.strided!(Iota!Dim)(Repeat!(Dim, factor));
-}
-
 private struct SweepKernel(T, size_t Dim)
 {
     import std.meta: Repeat;
@@ -131,10 +123,10 @@ void sweep_slice(Color color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const 
     auto kernel = SweepKernel!(T, 1)(h2);
 
     each!kernel(
-        U[2 - color .. $ - 1].strideAll(2),
-        U[1 - color .. $ - 2].strideAll(2),
-        U[3 - color .. $].strideAll(2),
-        F[2 - color .. $ - 1].strideAll(2));
+        U[2 - color .. $ - 1].strided(2),
+        U[1 - color .. $ - 2].strided(2),
+        U[3 - color .. $].strided(2),
+        F[2 - color .. $ - 1].strided(2));
 }
 
 /++ slow sweep for 2D +/
@@ -144,20 +136,20 @@ void sweep_slice(Color color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const 
     auto kernel = SweepKernel!(T, 2)(h2);
 
     each!kernel(
-        U[1 .. $ - 1, 1 + color .. $ - 1].strideAll(2),
-        U[0 .. $ - 2, 1 + color .. $ - 1].strideAll(2),
-        U[2 .. $, 1 + color .. $ - 1].strideAll(2),
-        U[1 .. $ - 1, color .. $ - 2].strideAll(2),
-        U[1 .. $ - 1, 2 + color .. $].strideAll(2),
-        F[1 .. $ - 1, 1 + color .. $ - 1].strideAll(2));
+        U[1 .. $ - 1, 1 + color .. $ - 1].strided(2),
+        U[0 .. $ - 2, 1 + color .. $ - 1].strided(2),
+        U[2 .. $, 1 + color .. $ - 1].strided(2),
+        U[1 .. $ - 1, color .. $ - 2].strided(2),
+        U[1 .. $ - 1, 2 + color .. $].strided(2),
+        F[1 .. $ - 1, 1 + color .. $ - 1].strided(2));
 
     each!kernel(
-        U[2 .. $ - 1, 2 - color .. $ - 1].strideAll(2),
-        U[1 .. $ - 2, 2 - color .. $ - 1].strideAll(2),
-        U[3 .. $, 2 - color .. $ - 1].strideAll(2),
-        U[2 .. $ - 1, 1 - color .. $ - 2].strideAll(2),
-        U[2 .. $ - 1, 3 - color .. $].strideAll(2),
-        F[2 .. $ - 1, 2 - color .. $ - 1].strideAll(2));
+        U[2 .. $ - 1, 2 - color .. $ - 1].strided(2),
+        U[1 .. $ - 2, 2 - color .. $ - 1].strided(2),
+        U[3 .. $, 2 - color .. $ - 1].strided(2),
+        U[2 .. $ - 1, 1 - color .. $ - 2].strided(2),
+        U[2 .. $ - 1, 3 - color .. $].strided(2),
+        F[2 .. $ - 1, 2 - color .. $ - 1].strided(2));
 }
 
 /++ slow sweep for 3D +/
@@ -167,44 +159,44 @@ void sweep_slice(Color color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const 
     auto kernel = SweepKernel!(T, 3)(h2);
 
     each!kernel(
-        U[2 .. $ - 1, 1 .. $ - 1, 1 + color .. $ - 1].strideAll(2),
-        U[1 .. $ - 2, 1 .. $ - 1, 1 + color .. $ - 1].strideAll(2),
-        U[3 .. $, 1 .. $ - 1, 1 + color .. $ - 1].strideAll(2),
-        U[2 .. $ - 1, 0 .. $ - 2, 1 + color .. $ - 1].strideAll(2),
-        U[2 .. $ - 1, 2 .. $, 1 + color .. $ - 1].strideAll(2),
-        U[2 .. $ - 1, 1 .. $ - 1, color .. $ - 2].strideAll(2),
-        U[2 .. $ - 1, 1 .. $ - 1, 2 + color .. $].strideAll(2),
-        F[2 .. $ - 1, 1 .. $ - 1, 1 + color .. $ - 1].strideAll(2));
+        U[2 .. $ - 1, 1 .. $ - 1, 1 + color .. $ - 1].strided(2),
+        U[1 .. $ - 2, 1 .. $ - 1, 1 + color .. $ - 1].strided(2),
+        U[3 .. $, 1 .. $ - 1, 1 + color .. $ - 1].strided(2),
+        U[2 .. $ - 1, 0 .. $ - 2, 1 + color .. $ - 1].strided(2),
+        U[2 .. $ - 1, 2 .. $, 1 + color .. $ - 1].strided(2),
+        U[2 .. $ - 1, 1 .. $ - 1, color .. $ - 2].strided(2),
+        U[2 .. $ - 1, 1 .. $ - 1, 2 + color .. $].strided(2),
+        F[2 .. $ - 1, 1 .. $ - 1, 1 + color .. $ - 1].strided(2));
 
     each!kernel(
-        U[1 .. $ - 1, 1 .. $ - 1, 2 - color .. $ - 1].strideAll(2),
-        U[0 .. $ - 2, 1 .. $ - 1, 2 - color .. $ - 1].strideAll(2),
-        U[2 .. $, 1 .. $ - 1, 2 - color .. $ - 1].strideAll(2),
-        U[1 .. $ - 1, 0 .. $ - 2, 2 - color .. $ - 1].strideAll(2),
-        U[1 .. $ - 1, 2 .. $, 2 - color .. $ - 1].strideAll(2),
-        U[1 .. $ - 1, 1 .. $ - 1, 1 - color .. $ - 2].strideAll(2),
-        U[1 .. $ - 1, 1 .. $ - 1, 3 - color .. $].strideAll(2),
-        F[1 .. $ - 1, 1 .. $ - 1, 2 - color .. $ - 1].strideAll(2));
+        U[1 .. $ - 1, 1 .. $ - 1, 2 - color .. $ - 1].strided(2),
+        U[0 .. $ - 2, 1 .. $ - 1, 2 - color .. $ - 1].strided(2),
+        U[2 .. $, 1 .. $ - 1, 2 - color .. $ - 1].strided(2),
+        U[1 .. $ - 1, 0 .. $ - 2, 2 - color .. $ - 1].strided(2),
+        U[1 .. $ - 1, 2 .. $, 2 - color .. $ - 1].strided(2),
+        U[1 .. $ - 1, 1 .. $ - 1, 1 - color .. $ - 2].strided(2),
+        U[1 .. $ - 1, 1 .. $ - 1, 3 - color .. $].strided(2),
+        F[1 .. $ - 1, 1 .. $ - 1, 2 - color .. $ - 1].strided(2));
 
     each!kernel(
-        U[1 .. $ - 1, 2 .. $ - 1, 1 + color .. $ - 1].strideAll(2),
-        U[0 .. $ - 2, 2 .. $ - 1, 1 + color .. $ - 1].strideAll(2),
-        U[2 .. $, 2 .. $ - 1, 1 + color .. $ - 1].strideAll(2),
-        U[1 .. $ - 1, 1 .. $ - 2, 1 + color .. $ - 1].strideAll(2),
-        U[1 .. $ - 1, 3 .. $, 1 + color .. $ - 1].strideAll(2),
-        U[1 .. $ - 1, 2 .. $ - 1, color .. $ - 2].strideAll(2),
-        U[1 .. $ - 1, 2 .. $ - 1, 2 + color .. $].strideAll(2),
-        F[1 .. $ - 1, 2 .. $ - 1, 1 + color .. $ - 1].strideAll(2));
+        U[1 .. $ - 1, 2 .. $ - 1, 1 + color .. $ - 1].strided(2),
+        U[0 .. $ - 2, 2 .. $ - 1, 1 + color .. $ - 1].strided(2),
+        U[2 .. $, 2 .. $ - 1, 1 + color .. $ - 1].strided(2),
+        U[1 .. $ - 1, 1 .. $ - 2, 1 + color .. $ - 1].strided(2),
+        U[1 .. $ - 1, 3 .. $, 1 + color .. $ - 1].strided(2),
+        U[1 .. $ - 1, 2 .. $ - 1, color .. $ - 2].strided(2),
+        U[1 .. $ - 1, 2 .. $ - 1, 2 + color .. $].strided(2),
+        F[1 .. $ - 1, 2 .. $ - 1, 1 + color .. $ - 1].strided(2));
 
     each!kernel(
-        U[2 .. $ - 1, 2 .. $ - 1, 2 - color .. $ - 1].strideAll(2),
-        U[1 .. $ - 2, 2 .. $ - 1, 2 - color .. $ - 1].strideAll(2),
-        U[3 .. $, 2 .. $ - 1, 2 - color .. $ - 1].strideAll(2),
-        U[2 .. $ - 1, 1 .. $ - 2, 2 - color .. $ - 1].strideAll(2),
-        U[2 .. $ - 1, 3 .. $, 2 - color .. $ - 1].strideAll(2),
-        U[2 .. $ - 1, 2 .. $ - 1, 1 - color .. $ - 2].strideAll(2),
-        U[2 .. $ - 1, 2 .. $ - 1, 3 - color .. $].strideAll(2),
-        F[2 .. $ - 1, 2 .. $ - 1, 2 - color .. $ - 1].strideAll(2));
+        U[2 .. $ - 1, 2 .. $ - 1, 2 - color .. $ - 1].strided(2),
+        U[1 .. $ - 2, 2 .. $ - 1, 2 - color .. $ - 1].strided(2),
+        U[3 .. $, 2 .. $ - 1, 2 - color .. $ - 1].strided(2),
+        U[2 .. $ - 1, 1 .. $ - 2, 2 - color .. $ - 1].strided(2),
+        U[2 .. $ - 1, 3 .. $, 2 - color .. $ - 1].strided(2),
+        U[2 .. $ - 1, 2 .. $ - 1, 1 - color .. $ - 2].strided(2),
+        U[2 .. $ - 1, 2 .. $ - 1, 3 - color .. $].strided(2),
+        F[2 .. $ - 1, 2 .. $ - 1, 2 - color .. $ - 1].strided(2));
 }
 
 /++ naive sweep for 1D +/

--- a/D/source/multid/gaussseidel/sweep.d
+++ b/D/source/multid/gaussseidel/sweep.d
@@ -2,7 +2,7 @@ module multid.gaussseidel.sweep;
 
 import mir.math: fastmath;
 import mir.algorithm.iteration: each;
-import mir.ndslice : slice, sliced, Slice, SliceKind, strided;
+import mir.ndslice : slice, sliced, Slice, SliceKind, stride;
 import multid.gaussseidel.redblack : Color;
 
 /++
@@ -123,10 +123,10 @@ void sweep_slice(Color color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const 
     auto kernel = SweepKernel!(T, 1)(h2);
 
     each!kernel(
-        U[2 - color .. $ - 1].strided(2),
-        U[1 - color .. $ - 2].strided(2),
-        U[3 - color .. $].strided(2),
-        F[2 - color .. $ - 1].strided(2));
+        U[2 - color .. $ - 1].stride,
+        U[1 - color .. $ - 2].stride,
+        U[3 - color .. $].stride,
+        F[2 - color .. $ - 1].stride);
 }
 
 /++ slow sweep for 2D +/
@@ -135,21 +135,21 @@ void sweep_slice(Color color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const 
 {
     auto kernel = SweepKernel!(T, 2)(h2);
 
-    each!kernel(
-        U[1 .. $ - 1, 1 + color .. $ - 1].strided(2),
-        U[0 .. $ - 2, 1 + color .. $ - 1].strided(2),
-        U[2 .. $, 1 + color .. $ - 1].strided(2),
-        U[1 .. $ - 1, color .. $ - 2].strided(2),
-        U[1 .. $ - 1, 2 + color .. $].strided(2),
-        F[1 .. $ - 1, 1 + color .. $ - 1].strided(2));
+    each!(each!kernel)(
+        U[1 .. $ - 1, 1 + color .. $ - 1].stride,
+        U[0 .. $ - 2, 1 + color .. $ - 1].stride,
+        U[2 .. $, 1 + color .. $ - 1].stride,
+        U[1 .. $ - 1, color .. $ - 2].stride,
+        U[1 .. $ - 1, 2 + color .. $].stride,
+        F[1 .. $ - 1, 1 + color .. $ - 1].stride);
 
-    each!kernel(
-        U[2 .. $ - 1, 2 - color .. $ - 1].strided(2),
-        U[1 .. $ - 2, 2 - color .. $ - 1].strided(2),
-        U[3 .. $, 2 - color .. $ - 1].strided(2),
-        U[2 .. $ - 1, 1 - color .. $ - 2].strided(2),
-        U[2 .. $ - 1, 3 - color .. $].strided(2),
-        F[2 .. $ - 1, 2 - color .. $ - 1].strided(2));
+    each!(each!kernel)(
+        U[2 .. $ - 1, 2 - color .. $ - 1].stride,
+        U[1 .. $ - 2, 2 - color .. $ - 1].stride,
+        U[3 .. $, 2 - color .. $ - 1].stride,
+        U[2 .. $ - 1, 1 - color .. $ - 2].stride,
+        U[2 .. $ - 1, 3 - color .. $].stride,
+        F[2 .. $ - 1, 2 - color .. $ - 1].stride);
 }
 
 /++ slow sweep for 3D +/
@@ -158,45 +158,45 @@ void sweep_slice(Color color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const 
 {
     auto kernel = SweepKernel!(T, 3)(h2);
 
-    each!kernel(
-        U[2 .. $ - 1, 1 .. $ - 1, 1 + color .. $ - 1].strided(2),
-        U[1 .. $ - 2, 1 .. $ - 1, 1 + color .. $ - 1].strided(2),
-        U[3 .. $, 1 .. $ - 1, 1 + color .. $ - 1].strided(2),
-        U[2 .. $ - 1, 0 .. $ - 2, 1 + color .. $ - 1].strided(2),
-        U[2 .. $ - 1, 2 .. $, 1 + color .. $ - 1].strided(2),
-        U[2 .. $ - 1, 1 .. $ - 1, color .. $ - 2].strided(2),
-        U[2 .. $ - 1, 1 .. $ - 1, 2 + color .. $].strided(2),
-        F[2 .. $ - 1, 1 .. $ - 1, 1 + color .. $ - 1].strided(2));
+    each!(each!(each!kernel))(
+        U[2 .. $ - 1, 1 .. $ - 1, 1 + color .. $ - 1].stride,
+        U[1 .. $ - 2, 1 .. $ - 1, 1 + color .. $ - 1].stride,
+        U[3 .. $, 1 .. $ - 1, 1 + color .. $ - 1].stride,
+        U[2 .. $ - 1, 0 .. $ - 2, 1 + color .. $ - 1].stride,
+        U[2 .. $ - 1, 2 .. $, 1 + color .. $ - 1].stride,
+        U[2 .. $ - 1, 1 .. $ - 1, color .. $ - 2].stride,
+        U[2 .. $ - 1, 1 .. $ - 1, 2 + color .. $].stride,
+        F[2 .. $ - 1, 1 .. $ - 1, 1 + color .. $ - 1].stride);
 
-    each!kernel(
-        U[1 .. $ - 1, 1 .. $ - 1, 2 - color .. $ - 1].strided(2),
-        U[0 .. $ - 2, 1 .. $ - 1, 2 - color .. $ - 1].strided(2),
-        U[2 .. $, 1 .. $ - 1, 2 - color .. $ - 1].strided(2),
-        U[1 .. $ - 1, 0 .. $ - 2, 2 - color .. $ - 1].strided(2),
-        U[1 .. $ - 1, 2 .. $, 2 - color .. $ - 1].strided(2),
-        U[1 .. $ - 1, 1 .. $ - 1, 1 - color .. $ - 2].strided(2),
-        U[1 .. $ - 1, 1 .. $ - 1, 3 - color .. $].strided(2),
-        F[1 .. $ - 1, 1 .. $ - 1, 2 - color .. $ - 1].strided(2));
+    each!(each!(each!kernel))(
+        U[1 .. $ - 1, 1 .. $ - 1, 2 - color .. $ - 1].stride,
+        U[0 .. $ - 2, 1 .. $ - 1, 2 - color .. $ - 1].stride,
+        U[2 .. $, 1 .. $ - 1, 2 - color .. $ - 1].stride,
+        U[1 .. $ - 1, 0 .. $ - 2, 2 - color .. $ - 1].stride,
+        U[1 .. $ - 1, 2 .. $, 2 - color .. $ - 1].stride,
+        U[1 .. $ - 1, 1 .. $ - 1, 1 - color .. $ - 2].stride,
+        U[1 .. $ - 1, 1 .. $ - 1, 3 - color .. $].stride,
+        F[1 .. $ - 1, 1 .. $ - 1, 2 - color .. $ - 1].stride);
 
-    each!kernel(
-        U[1 .. $ - 1, 2 .. $ - 1, 1 + color .. $ - 1].strided(2),
-        U[0 .. $ - 2, 2 .. $ - 1, 1 + color .. $ - 1].strided(2),
-        U[2 .. $, 2 .. $ - 1, 1 + color .. $ - 1].strided(2),
-        U[1 .. $ - 1, 1 .. $ - 2, 1 + color .. $ - 1].strided(2),
-        U[1 .. $ - 1, 3 .. $, 1 + color .. $ - 1].strided(2),
-        U[1 .. $ - 1, 2 .. $ - 1, color .. $ - 2].strided(2),
-        U[1 .. $ - 1, 2 .. $ - 1, 2 + color .. $].strided(2),
-        F[1 .. $ - 1, 2 .. $ - 1, 1 + color .. $ - 1].strided(2));
+    each!(each!(each!kernel))(
+        U[1 .. $ - 1, 2 .. $ - 1, 1 + color .. $ - 1].stride,
+        U[0 .. $ - 2, 2 .. $ - 1, 1 + color .. $ - 1].stride,
+        U[2 .. $, 2 .. $ - 1, 1 + color .. $ - 1].stride,
+        U[1 .. $ - 1, 1 .. $ - 2, 1 + color .. $ - 1].stride,
+        U[1 .. $ - 1, 3 .. $, 1 + color .. $ - 1].stride,
+        U[1 .. $ - 1, 2 .. $ - 1, color .. $ - 2].stride,
+        U[1 .. $ - 1, 2 .. $ - 1, 2 + color .. $].stride,
+        F[1 .. $ - 1, 2 .. $ - 1, 1 + color .. $ - 1].stride);
 
-    each!kernel(
-        U[2 .. $ - 1, 2 .. $ - 1, 2 - color .. $ - 1].strided(2),
-        U[1 .. $ - 2, 2 .. $ - 1, 2 - color .. $ - 1].strided(2),
-        U[3 .. $, 2 .. $ - 1, 2 - color .. $ - 1].strided(2),
-        U[2 .. $ - 1, 1 .. $ - 2, 2 - color .. $ - 1].strided(2),
-        U[2 .. $ - 1, 3 .. $, 2 - color .. $ - 1].strided(2),
-        U[2 .. $ - 1, 2 .. $ - 1, 1 - color .. $ - 2].strided(2),
-        U[2 .. $ - 1, 2 .. $ - 1, 3 - color .. $].strided(2),
-        F[2 .. $ - 1, 2 .. $ - 1, 2 - color .. $ - 1].strided(2));
+    each!(each!(each!kernel))(
+        U[2 .. $ - 1, 2 .. $ - 1, 2 - color .. $ - 1].stride,
+        U[1 .. $ - 2, 2 .. $ - 1, 2 - color .. $ - 1].stride,
+        U[3 .. $, 2 .. $ - 1, 2 - color .. $ - 1].stride,
+        U[2 .. $ - 1, 1 .. $ - 2, 2 - color .. $ - 1].stride,
+        U[2 .. $ - 1, 3 .. $, 2 - color .. $ - 1].stride,
+        U[2 .. $ - 1, 2 .. $ - 1, 1 - color .. $ - 2].stride,
+        U[2 .. $ - 1, 2 .. $ - 1, 3 - color .. $].stride,
+        F[2 .. $ - 1, 2 .. $ - 1, 2 - color .. $ - 1].stride);
 }
 
 /++ naive sweep for 1D +/

--- a/D/source/multid/gaussseidel/sweep.d
+++ b/D/source/multid/gaussseidel/sweep.d
@@ -2,7 +2,7 @@ module multid.gaussseidel.sweep;
 
 import mir.math: fastmath;
 import mir.algorithm.iteration: each;
-import mir.ndslice : slice, sliced, Slice, SliceKind, stride;
+import mir.ndslice : assumeSameShape, slice, sliced, Slice, SliceKind, stride;
 import multid.gaussseidel.redblack : Color;
 
 /++
@@ -17,6 +17,7 @@ Params:
 @nogc @fastmath
 void sweep_field(Color color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const T h2) nothrow
 {
+    assumeSameShape(F, U);
     const auto N = F.shape[0];
     auto UF = U.field;
     auto FF = F.field;
@@ -38,6 +39,7 @@ Params:
 @nogc @fastmath
 void sweep_field(Color color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const T h2) nothrow
 {
+    assumeSameShape(F, U);
     const auto m = F.shape[0];
     const auto n = F.shape[1];
     auto UF = U.field;
@@ -70,6 +72,7 @@ Params:
 @nogc @fastmath
 void sweep_field(Color color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const T h2) nothrow
 {
+    assumeSameShape(F, U);
     const auto m = F.shape[0];
     const auto n = F.shape[1];
     const auto l = F.shape[2];
@@ -120,6 +123,7 @@ private struct SweepKernel(T, size_t Dim)
 @nogc @fastmath
 void sweep_slice(Color color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const T h2) nothrow
 {
+    assumeSameShape(F, U);
     auto kernel = SweepKernel!(T, 1)(h2);
 
     each!kernel(
@@ -133,6 +137,7 @@ void sweep_slice(Color color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const 
 @nogc @fastmath
 void sweep_slice(Color color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const T h2) nothrow
 {
+    assumeSameShape(F, U);
     auto kernel = SweepKernel!(T, 2)(h2);
 
     each!(each!kernel)(
@@ -156,6 +161,7 @@ void sweep_slice(Color color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const 
 @nogc @fastmath
 void sweep_slice(Color color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const T h2) nothrow
 {
+    assumeSameShape(F, U);
     auto kernel = SweepKernel!(T, 3)(h2);
 
     each!(each!(each!kernel))(
@@ -203,6 +209,7 @@ void sweep_slice(Color color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const 
 @nogc @fastmath
 void sweep_naive(Color color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const T h2) nothrow
 {
+    assumeSameShape(F, U);
 
     const auto n = F.shape[0];
     foreach (i; 1 .. n - 1)
@@ -218,6 +225,7 @@ void sweep_naive(Color color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const 
 @nogc @fastmath
 void sweep_naive(Color color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const T h2) nothrow
 {
+    assumeSameShape(F, U);
     const auto n = F.shape[0];
     const auto m = F.shape[1];
 
@@ -236,6 +244,7 @@ void sweep_naive(Color color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const 
 @nogc @fastmath
 void sweep_naive(Color color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const T h2) nothrow
 {
+    assumeSameShape(F, U);
     const auto n = F.shape[0];
     const auto m = F.shape[1];
     const auto l = F.shape[2];

--- a/D/source/multid/gaussseidel/sweep.d
+++ b/D/source/multid/gaussseidel/sweep.d
@@ -1,6 +1,8 @@
 module multid.gaussseidel.sweep;
 
-import mir.ndslice : slice, sliced, Slice, strided;
+import mir.math: fastmath;
+import mir.algorithm.iteration: each;
+import mir.ndslice : slice, sliced, Slice, SliceKind, strided;
 import multid.gaussseidel.redblack : Color;
 
 /++
@@ -12,15 +14,15 @@ Params:
     U  = slice of dimension Dim
     h2 = the squared distance between the grid points
 +/
-@nogc
-void sweep_field(T, size_t Dim : 1, Color color)(in Slice!(T*, 1) F, Slice!(T*, 1) U, in T h2) nothrow
+@nogc @fastmath
+void sweep_field(Color color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const T h2) nothrow
 {
     const auto N = F.shape[0];
     auto UF = U.field;
     auto FF = F.field;
     for (size_t i = 2u - color; i < N - 1u; i += 2u)
     {
-        UF[i] = (UF[i - 1u] + UF[i + 1u] - FF[i] * h2) / 2.0;
+        UF[i] = (UF[i - 1u] + UF[i + 1u] - FF[i] * h2) * (T(1) /  2);
     }
 }
 
@@ -33,8 +35,8 @@ Params:
     U  = slice of dimension Dim
     h2 = the squared distance between the grid points
 +/
-@nogc
-void sweep_field(T, size_t Dim : 2, Color color)(in Slice!(T*, 2) F, Slice!(T*, 2) U, in T h2) nothrow
+@nogc @fastmath
+void sweep_field(Color color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const T h2) nothrow
 {
     const auto m = F.shape[0];
     const auto n = F.shape[1];
@@ -51,7 +53,7 @@ void sweep_field(T, size_t Dim : 2, Color color)(in Slice!(T*, 2) F, Slice!(T*, 
                     UF[flatindex - m] +
                     UF[flatindex + m] +
                     UF[flatindex - 1] +
-                    UF[flatindex + 1] - h2 * FF[flatindex]) / cast(T) 4;
+                    UF[flatindex + 1] - h2 * FF[flatindex]) * (T(1) / 4);
         }
     }
 }
@@ -65,8 +67,8 @@ Params:
     U  = slice of dimension Dim
     h2 = the squared distance between the grid points
 +/
-@nogc
-void sweep_field(T, size_t Dim : 3, Color color)(in Slice!(T*, 3) F, Slice!(T*, 3) U, in T h2) nothrow
+@nogc @fastmath
+void sweep_field(Color color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const T h2) nothrow
 {
     const auto m = F.shape[0];
     const auto n = F.shape[1];
@@ -87,96 +89,127 @@ void sweep_field(T, size_t Dim : 3, Color color)(in Slice!(T*, 3) F, Slice!(T*, 
                         UF[flatindex - l] +
                         UF[flatindex + l] +
                         UF[flatindex - 1] +
-                        UF[flatindex + 1] - h2 * FF[flatindex]) / 6.0;
+                        UF[flatindex + 1] - h2 * FF[flatindex]) * (T(1) / 6);
             }
         }
     }
 }
 
-/++ slow sweep for 1D +/
-@nogc
-void sweep_slice(T, size_t Dim : 1, Color color)(in Slice!(T*, 1) F, Slice!(T*, 1) U, in T h2) nothrow
+// TODO: add to Mir
+@fastmath auto strideAll(T, size_t Dim, SliceKind kind)(Slice!(T*, Dim, kind) slice, size_t factor)
 {
-    U[2 - color .. $ - 1].strided!0(2)[] = (
-            U[1 - color .. $ - 2].strided!0(2) + U[3 - color .. $].strided!0(
-            2) - h2 * F[2 - color .. $ - 1].strided!0(2)) / 2.0;
+    import mir.internal.utility: Iota;
+    import std.meta: Repeat;
+    return slice.strided!(Iota!Dim)(Repeat!(Dim, factor));
+}
+
+private struct SweepKernel(T, size_t Dim)
+{
+    import std.meta: Repeat;
+
+    T h2;
+
+    this(T h2)
+    {
+        this.h2 = h2;
+    }
+
+    @fastmath
+    void opCall()(ref scope T r, ref scope const Repeat!(2 * Dim, T) neighbors, ref scope const T f) const
+    {
+        T sum = neighbors[0];
+        foreach (ref neighbor; neighbors[1 .. $])
+            sum += neighbor;
+        r = (sum - f * h2) * (T(1) / neighbors.length);
+    }
+}
+
+/++ slow sweep for 1D +/
+@nogc @fastmath
+void sweep_slice(Color color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const T h2) nothrow
+{
+    auto kernel = SweepKernel!(T, 1)(h2);
+
+    each!kernel(
+        U[2 - color .. $ - 1].strideAll(2),
+        U[1 - color .. $ - 2].strideAll(2),
+        U[3 - color .. $].strideAll(2),
+        F[2 - color .. $ - 1].strideAll(2));
 }
 
 /++ slow sweep for 2D +/
-@nogc
-void sweep_slice(T, size_t Dim : 2, Color color)(in Slice!(T*, 2) F, Slice!(T*, 2) U, in T h2) nothrow
+@nogc @fastmath
+void sweep_slice(Color color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const T h2) nothrow
 {
-    const auto m = F.shape[0];
-    const auto n = F.shape[1];
-    auto strideU = U[1 .. m - 1, 1 + color .. n - 1].strided!(0, 1)(2, 2);
-    strideU[] = U[0 .. m - 2, 1 + color .. n - 1].strided!(0, 1)(2, 2);
-    strideU[] += U[2 .. m, 1 + color .. n - 1].strided!(0, 1)(2, 2);
-    strideU[] += U[1 .. m - 1, color .. n - 2].strided!(0, 1)(2, 2);
-    strideU[] += U[1 .. m - 1, 2 + color .. n].strided!(0, 1)(2, 2);
-    strideU[] -= F[1 .. m - 1, 1 + color .. n - 1].strided!(0, 1)(2, 2) * h2;
-    strideU[] /= cast(T) 4;
+    auto kernel = SweepKernel!(T, 2)(h2);
 
-    strideU = U[2 .. m - 1, 2 - color .. n - 1].strided!(0, 1)(2, 2);
-    strideU[] = U[1 .. m - 2, 2 - color .. n - 1].strided!(0, 1)(2, 2);
-    strideU[] += U[3 .. m, 2 - color .. n - 1].strided!(0, 1)(2, 2);
-    strideU[] += U[2 .. m - 1, 1 - color .. n - 2].strided!(0, 1)(2, 2);
-    strideU[] += U[2 .. m - 1, 3 - color .. n].strided!(0, 1)(2, 2);
-    strideU[] -= F[2 .. m - 1, 2 - color .. n - 1].strided!(0, 1)(2, 2) * h2;
-    strideU[] /= cast(T) 4;
+    each!kernel(
+        U[1 .. $ - 1, 1 + color .. $ - 1].strideAll(2),
+        U[0 .. $ - 2, 1 + color .. $ - 1].strideAll(2),
+        U[2 .. $, 1 + color .. $ - 1].strideAll(2),
+        U[1 .. $ - 1, color .. $ - 2].strideAll(2),
+        U[1 .. $ - 1, 2 + color .. $].strideAll(2),
+        F[1 .. $ - 1, 1 + color .. $ - 1].strideAll(2));
+
+    each!kernel(
+        U[2 .. $ - 1, 2 - color .. $ - 1].strideAll(2),
+        U[1 .. $ - 2, 2 - color .. $ - 1].strideAll(2),
+        U[3 .. $, 2 - color .. $ - 1].strideAll(2),
+        U[2 .. $ - 1, 1 - color .. $ - 2].strideAll(2),
+        U[2 .. $ - 1, 3 - color .. $].strideAll(2),
+        F[2 .. $ - 1, 2 - color .. $ - 1].strideAll(2));
 }
+
 /++ slow sweep for 3D +/
-@nogc
-void sweep_slice(T, size_t Dim : 3, Color color)(in Slice!(T*, 3) F, Slice!(T*, 3) U, in T h2) nothrow
+@nogc @fastmath
+void sweep_slice(Color color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const T h2) nothrow
 {
-    const auto m = F.shape[0];
-    const auto n = F.shape[1];
-    const auto o = F.shape[2];
+    auto kernel = SweepKernel!(T, 3)(h2);
 
-    auto strideU = U[2 .. m - 1, 1 .. n - 1, 1 + color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] = U[1 .. m - 2, 1 .. n - 1, 1 + color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[3 .. m, 1 .. n - 1, 1 + color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[2 .. m - 1, 0 .. n - 2, 1 + color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[2 .. m - 1, 2 .. n, 1 + color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[2 .. m - 1, 1 .. n - 1, color .. o - 2].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[2 .. m - 1, 1 .. n - 1, 2 + color .. o].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] -= F[2 .. m - 1, 1 .. n - 1, 1 + color .. o - 1].strided!(0, 1, 2)(2, 2, 2) * h2;
-    strideU[] /= cast(T) 6;
+    each!kernel(
+        U[2 .. $ - 1, 1 .. $ - 1, 1 + color .. $ - 1].strideAll(2),
+        U[1 .. $ - 2, 1 .. $ - 1, 1 + color .. $ - 1].strideAll(2),
+        U[3 .. $, 1 .. $ - 1, 1 + color .. $ - 1].strideAll(2),
+        U[2 .. $ - 1, 0 .. $ - 2, 1 + color .. $ - 1].strideAll(2),
+        U[2 .. $ - 1, 2 .. $, 1 + color .. $ - 1].strideAll(2),
+        U[2 .. $ - 1, 1 .. $ - 1, color .. $ - 2].strideAll(2),
+        U[2 .. $ - 1, 1 .. $ - 1, 2 + color .. $].strideAll(2),
+        F[2 .. $ - 1, 1 .. $ - 1, 1 + color .. $ - 1].strideAll(2));
 
-    strideU = U[1 .. m - 1, 1 .. n - 1, 2 - color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] = U[0 .. m - 2, 1 .. n - 1, 2 - color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[2 .. m, 1 .. n - 1, 2 - color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[1 .. m - 1, 0 .. n - 2, 2 - color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[1 .. m - 1, 2 .. n, 2 - color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[1 .. m - 1, 1 .. n - 1, 1 - color .. o - 2].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[1 .. m - 1, 1 .. n - 1, 3 - color .. o].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] -= F[1 .. m - 1, 1 .. n - 1, 2 - color .. o - 1].strided!(0, 1, 2)(2, 2, 2) * h2;
-    strideU[] /= cast(T) 6;
+    each!kernel(
+        U[1 .. $ - 1, 1 .. $ - 1, 2 - color .. $ - 1].strideAll(2),
+        U[0 .. $ - 2, 1 .. $ - 1, 2 - color .. $ - 1].strideAll(2),
+        U[2 .. $, 1 .. $ - 1, 2 - color .. $ - 1].strideAll(2),
+        U[1 .. $ - 1, 0 .. $ - 2, 2 - color .. $ - 1].strideAll(2),
+        U[1 .. $ - 1, 2 .. $, 2 - color .. $ - 1].strideAll(2),
+        U[1 .. $ - 1, 1 .. $ - 1, 1 - color .. $ - 2].strideAll(2),
+        U[1 .. $ - 1, 1 .. $ - 1, 3 - color .. $].strideAll(2),
+        F[1 .. $ - 1, 1 .. $ - 1, 2 - color .. $ - 1].strideAll(2));
 
-    strideU = U[1 .. m - 1, 2 .. n - 1, 1 + color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] = U[0 .. m - 2, 2 .. n - 1, 1 + color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[2 .. m, 2 .. n - 1, 1 + color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[1 .. m - 1, 1 .. n - 2, 1 + color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[1 .. m - 1, 3 .. n, 1 + color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[1 .. m - 1, 2 .. n - 1, color .. o - 2].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[1 .. m - 1, 2 .. n - 1, 2 + color .. o].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] -= F[1 .. m - 1, 2 .. n - 1, 1 + color .. o - 1].strided!(0, 1, 2)(2, 2, 2) * h2;
-    strideU[] /= cast(T) 6;
+    each!kernel(
+        U[1 .. $ - 1, 2 .. $ - 1, 1 + color .. $ - 1].strideAll(2),
+        U[0 .. $ - 2, 2 .. $ - 1, 1 + color .. $ - 1].strideAll(2),
+        U[2 .. $, 2 .. $ - 1, 1 + color .. $ - 1].strideAll(2),
+        U[1 .. $ - 1, 1 .. $ - 2, 1 + color .. $ - 1].strideAll(2),
+        U[1 .. $ - 1, 3 .. $, 1 + color .. $ - 1].strideAll(2),
+        U[1 .. $ - 1, 2 .. $ - 1, color .. $ - 2].strideAll(2),
+        U[1 .. $ - 1, 2 .. $ - 1, 2 + color .. $].strideAll(2),
+        F[1 .. $ - 1, 2 .. $ - 1, 1 + color .. $ - 1].strideAll(2));
 
-    strideU = U[2 .. m - 1, 2 .. n - 1, 2 - color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] = U[1 .. m - 2, 2 .. n - 1, 2 - color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[3 .. m, 2 .. n - 1, 2 - color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[2 .. m - 1, 1 .. n - 2, 2 - color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[2 .. m - 1, 3 .. n, 2 - color .. o - 1].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[2 .. m - 1, 2 .. n - 1, 1 - color .. o - 2].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] += U[2 .. m - 1, 2 .. n - 1, 3 - color .. o].strided!(0, 1, 2)(2, 2, 2);
-    strideU[] -= F[2 .. m - 1, 2 .. n - 1, 2 - color .. o - 1].strided!(0, 1, 2)(2, 2, 2) * h2;
-    strideU[] /= cast(T) 6;
-
+    each!kernel(
+        U[2 .. $ - 1, 2 .. $ - 1, 2 - color .. $ - 1].strideAll(2),
+        U[1 .. $ - 2, 2 .. $ - 1, 2 - color .. $ - 1].strideAll(2),
+        U[3 .. $, 2 .. $ - 1, 2 - color .. $ - 1].strideAll(2),
+        U[2 .. $ - 1, 1 .. $ - 2, 2 - color .. $ - 1].strideAll(2),
+        U[2 .. $ - 1, 3 .. $, 2 - color .. $ - 1].strideAll(2),
+        U[2 .. $ - 1, 2 .. $ - 1, 1 - color .. $ - 2].strideAll(2),
+        U[2 .. $ - 1, 2 .. $ - 1, 3 - color .. $].strideAll(2),
+        F[2 .. $ - 1, 2 .. $ - 1, 2 - color .. $ - 1].strideAll(2));
 }
 
 /++ naive sweep for 1D +/
-@nogc
-void sweep_naive(T, size_t Dim : 1, Color color)(const Slice!(T*, 1) F, Slice!(T*, 1) U, T h2) nothrow
+@nogc @fastmath
+void sweep_naive(Color color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const T h2) nothrow
 {
 
     const auto n = F.shape[0];
@@ -184,14 +217,14 @@ void sweep_naive(T, size_t Dim : 1, Color color)(const Slice!(T*, 1) F, Slice!(T
     {
         if (i % 2 == color)
         {
-            U[i] = (U[i - 1u] + U[i + 1u] - F[i] * h2) / 2.0;
+            U[i] = (U[i - 1u] + U[i + 1u] - F[i] * h2) * (T(1) /  2);
         }
     }
 
 }
 /++ naive sweep for 2D +/
-@nogc
-void sweep_naive(T, size_t Dim : 2, Color color)(const Slice!(T*, 2) F, Slice!(T*, 2) U, T h2) nothrow
+@nogc @fastmath
+void sweep_naive(Color color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const T h2) nothrow
 {
     const auto n = F.shape[0];
     const auto m = F.shape[1];
@@ -202,14 +235,14 @@ void sweep_naive(T, size_t Dim : 2, Color color)(const Slice!(T*, 2) F, Slice!(T
         {
             if ((i + j) % 2 == color)
             {
-                U[i, j] = (U[i - 1, j] + U[i + 1, j] + U[i, j - 1] + U[i, j + 1] - h2 * F[i, j]) / 4.0;
+                U[i, j] = (U[i - 1, j] + U[i + 1, j] + U[i, j - 1] + U[i, j + 1] - h2 * F[i, j]) * (T(1) / 4);
             }
         }
     }
 }
 /++ naive sweep for 3D +/
-@nogc
-void sweep_naive(T, size_t Dim : 3, Color color)(const Slice!(T*, 3) F, Slice!(T*, 3) U, T h2) nothrow
+@nogc @fastmath
+void sweep_naive(Color color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const T h2) nothrow
 {
     const auto n = F.shape[0];
     const auto m = F.shape[1];
@@ -223,7 +256,7 @@ void sweep_naive(T, size_t Dim : 3, Color color)(const Slice!(T*, 3) F, Slice!(T
                 if ((i + j + k) % 2 == color)
                 {
                     U[i, j, k] = (U[i - 1, j, k] + U[i + 1, j, k] + U[i, j - 1,
-                            k] + U[i, j + 1, k] + U[i, j, k - 1] + U[i, j, k + 1] - h2 * F[i, j, k]) / 6.0;
+                            k] + U[i, j + 1, k] + U[i, j, k - 1] + U[i, j, k + 1] - h2 * F[i, j, k]) * (T(1) / 6);
                 }
             }
         }

--- a/D/source/multid/gaussseidel/sweep.d
+++ b/D/source/multid/gaussseidel/sweep.d
@@ -2,17 +2,17 @@ module multid.gaussseidel.sweep;
 
 import mir.math: fastmath;
 import mir.algorithm.iteration: Chequer, each;
-import mir.ndslice : assumeSameShape, slice, sliced, Slice, SliceKind, strided, dropBorders, withNeighboursSum;
+import mir.ndslice : assumeSameShape, slice, sliced, Slice, SliceKind, strided, dropBorders, withNeighboursSum, zip;
 
 
 @nogc @fastmath
-void sweep_ndslice(Chequer color, T, size_t N)(Slice!(const(T)*, N) F, Slice!(T*, N) U, const T h2) nothrow
+void sweep_ndslice(T, size_t N)(Chequer color, Slice!(const(T)*, N) F, Slice!(T*, N) U, const T h2) nothrow
 {
     // find the naive implementation R/B order
-    enum Chequer c = N % 2 ? cast(Chequer)!color : color;
+    color = N % 2 ? cast(Chequer)!color : color;
     assumeSameShape(F, U);
-    c.each!((u, f) => u.a = (T(1) / (2 * N)) * (u.b - h2 * f))
-        (U.withNeighboursSum, F.dropBorders);
+    color.each!(z => z.a.a = (T(1) / (2 * N)) * (z.a.b - h2 * z.b))
+        (U.withNeighboursSum.zip!true(F.dropBorders));
 }
 
 /++
@@ -25,7 +25,7 @@ Params:
     h2 = the squared distance between the grid points
 +/
 @nogc @fastmath
-void sweep_field(Chequer color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const T h2) nothrow
+void sweep_field(T)(Chequer color, Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const T h2) nothrow
 {
     const N = F.shape[0];
     auto UF = U.field;
@@ -46,7 +46,7 @@ Params:
     h2 = the squared distance between the grid points
 +/
 @nogc @fastmath
-void sweep_field(Chequer color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const T h2) nothrow
+void sweep_field(T)(Chequer color, Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const T h2) nothrow
 {
     const m = F.shape[0];
     const n = F.shape[1];
@@ -78,7 +78,7 @@ Params:
     h2 = the squared distance between the grid points
 +/
 @nogc @fastmath
-void sweep_field(Chequer color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const T h2) nothrow
+void sweep_field(T)(Chequer color, Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const T h2) nothrow
 {
     const m = F.shape[0];
     const n = F.shape[1];
@@ -128,7 +128,7 @@ private struct SweepKernel(T, size_t Dim)
 
 /++ slow sweep for 1D +/
 @nogc @fastmath
-void sweep_slice(Chequer color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const T h2) nothrow
+void sweep_slice(T)(Chequer color, Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const T h2) nothrow
 {
     assumeSameShape(F, U);
     auto kernel = SweepKernel!(T, 1)(h2);
@@ -142,7 +142,7 @@ void sweep_slice(Chequer color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, cons
 
 /++ slow sweep for 2D +/
 @nogc @fastmath
-void sweep_slice(Chequer color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const T h2) nothrow
+void sweep_slice(T)(Chequer color, Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const T h2) nothrow
 {
     assumeSameShape(F, U);
     auto kernel = SweepKernel!(T, 2)(h2);
@@ -166,7 +166,7 @@ void sweep_slice(Chequer color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, cons
 
 /++ slow sweep for 3D +/
 @nogc @fastmath
-void sweep_slice(Chequer color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const T h2) nothrow
+void sweep_slice(T)(Chequer color, Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const T h2) nothrow
 {
     assumeSameShape(F, U);
     auto kernel = SweepKernel!(T, 3)(h2);
@@ -214,7 +214,7 @@ void sweep_slice(Chequer color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, cons
 
 /++ naive sweep for 1D +/
 @nogc @fastmath
-void sweep_naive(Chequer color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const T h2) nothrow
+void sweep_naive(T)(Chequer color, Slice!(const(T)*, 1) F, Slice!(T*, 1) U, const T h2) nothrow
 {
     foreach (i; 1 .. F.length - 1)
         if (i % 2 == color)
@@ -222,7 +222,7 @@ void sweep_naive(Chequer color, T)(Slice!(const(T)*, 1) F, Slice!(T*, 1) U, cons
 }
 /++ naive sweep for 2D +/
 @nogc @fastmath
-void sweep_naive(Chequer color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const T h2) nothrow
+void sweep_naive(T)(Chequer color, Slice!(const(T)*, 2) F, Slice!(T*, 2) U, const T h2) nothrow
 {
     foreach (i; 1 .. F.length!0 - 1)
     foreach (j; 1 .. F.length!1 - 1)
@@ -231,7 +231,7 @@ void sweep_naive(Chequer color, T)(Slice!(const(T)*, 2) F, Slice!(T*, 2) U, cons
 }
 /++ naive sweep for 3D +/
 @nogc @fastmath
-void sweep_naive(Chequer color, T)(Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const T h2) nothrow
+void sweep_naive(T)(Chequer color, Slice!(const(T)*, 3) F, Slice!(T*, 3) U, const T h2) nothrow
 {
     foreach (i; 1 .. F.length!0 - 1)
     foreach (j; 1 .. F.length!1 - 1)

--- a/D/source/multid/multigrid/cycle.d
+++ b/D/source/multid/multigrid/cycle.d
@@ -220,7 +220,7 @@ unittest
     import multid.tools.apply_poisson : compute_residual;
     import multid.tools.norm : nrmL2;
 
-    const auto norm_before = compute_residual(F, U, h).nrmL2;
+    const norm_before = compute_residual(F, U, h).nrmL2;
     F[0][0 .. $] = 1.0;
     F[1 .. $, 0] = 1.0;
     F[$ - 1][1 .. $] = 0.0;
@@ -228,7 +228,7 @@ unittest
     auto p = new PoissonCycle!(double, 2, 2, 2)(F, 2, 0, h);
     p.cycle(U);
 
-    const auto norm_after = compute_residual(F, U, h).nrmL2;
+    const norm_after = compute_residual(F, U, h).nrmL2;
 
     assert(U[0][0 .. $].all!"a == 1.0");
     assert(U[1 .. $, 0].all!"a == 1.0");

--- a/D/source/multid/multigrid/cycle.d
+++ b/D/source/multid/multigrid/cycle.d
@@ -137,7 +137,7 @@ public:
     v2 = number of postsmoothing steps
     eps = the epsilon the is used in the cycle esspecially in the solve step as stopcriteria
 +/
-class PoissonCycle(T, size_t Dim, uint v1, uint v2, SweepType sweep = SweepType.field,
+final class PoissonCycle(T, size_t Dim, uint v1, uint v2, SweepType sweep = SweepType.field,
         T eps = 1e-8) : Cycle!(T, Dim) if (1 <= Dim && Dim <= 3 && isFloatingPoint!T)
 {
     import multid.gaussseidel.redblack : GS_RB;

--- a/D/source/multid/multigrid/cycle.d
+++ b/D/source/multid/multigrid/cycle.d
@@ -15,11 +15,11 @@ class Cycle(T, size_t Dim) if (1 <= Dim && Dim <= 3 && isFloatingPoint!T)
 {
 protected:
     uint mu, l;
-    Slice!(T*, Dim) initialF;
+    Slice!(const(T)*, Dim) initialF;
     T[] Rdata;
     Slice!(T*, Dim + 1)[] temp;
 
-    final auto R(size_t[Dim] shape)
+    @nogc final auto R(size_t[Dim] shape)
     {
         return Rdata[0 .. shape.iota.elementCount].sliced(shape);
     }
@@ -83,7 +83,7 @@ public:
         l = the depth of the multigrid cycle if it is set to 0, the maxmium depth is choosen
         h = is the distance between the grid points if set to 0 1 / F.length is used
     +/
-    this(Slice!(T*, Dim) F, uint mu, uint l, T h)
+    this(Slice!(const(T)*, Dim) F, uint mu, uint l, T h)
     {
         auto ls = F.shape[0].to!double.log2;
         enforce!"l is to big for F"(l == 0 || ls > l);
@@ -113,7 +113,7 @@ public:
     /++
         This computes the residual
     +/
-    @nogc Slice!(T*, Dim) residual(Slice!(T*, Dim) F, Slice!(T*, Dim) U)
+    @nogc Slice!(T*, Dim) residual(Slice!(const(T)*, Dim) F, Slice!(const(T)*, Dim) U)
     {
         return compute_residual(F, U, this.h);
     }
@@ -121,13 +121,13 @@ public:
     /++
         The actual function to caculate a cycle
     +/
-    void cycle(Slice!(T*, Dim) U)
+    @nogc void cycle(Slice!(T*, Dim) U)
     {
         do_cycle(this.initialF, U, 0, this.h);
     }
 
     /++ Computes the l2 norm of U and the inital F+/
-    @nogc abstract T norm(Slice!(T*, Dim) U);
+    @nogc abstract T norm(Slice!(const(T)*, Dim) U);
 }
 
 /++ Poisson Cycle:
@@ -187,12 +187,12 @@ public:
         l = the depth of the multigrid cycle if it is set to 0, the maxmium depth is choosen
         h = is the distance between the grid points if set to 0 1 / F.length is used
     +/
-    this(Slice!(T*, Dim) F, uint mu, uint l, T h)
+    this(Slice!(const(T)*, Dim) F, uint mu, uint l, T h)
     {
         super(F, mu, l, h);
     }
 
-    override T norm(Slice!(T*, Dim) U)
+    override T norm(Slice!(const(T)*, Dim) U)
     {
         import multid.tools.norm : nrmL2;
 

--- a/D/source/multid/multigrid/cycle.d
+++ b/D/source/multid/multigrid/cycle.d
@@ -11,7 +11,7 @@ import std.traits : isFloatingPoint;
 /++
     Abstract base class for the Cycles it implements the base MG sheme
 +/
-class Cycle(T, size_t Dim) if (1 <= Dim && Dim <= 3 && isFloatingPoint!T)
+class Cycle(T, size_t Dim) if (1 <= Dim && isFloatingPoint!T)
 {
 protected:
     uint mu, l;
@@ -137,8 +137,9 @@ public:
 final class PoissonCycle(
     T,
     size_t Dim,
-    SweepType sweep = SweepType.field,
-) : Cycle!(T, Dim) if (1 <= Dim && Dim <= 3 && isFloatingPoint!T)
+    SweepType sweep = SweepType.ndslice,
+) : Cycle!(T, Dim)
+    if (1 <= Dim && (Dim <= 3 || SweepType.ndslice && Dim <= 8) && isFloatingPoint!T)
 {
     import multid.gaussseidel.redblack : GS_RB;
 
@@ -250,4 +251,10 @@ unittest
 
     // it should be at least a bit smaller than before
     assert(norm_after <= norm_before);
+}
+
+unittest
+{
+    // check we can compile 5-dimensional algorithm, 6-dim and higher are quite slow
+    alias PC5 = PoissonCycle!(double, 5, SweepType.ndslice);
 }

--- a/D/source/multid/multigrid/multigrid.d
+++ b/D/source/multid/multigrid/multigrid.d
@@ -16,7 +16,7 @@ Slice!(T*, Dim) multigrid(T, size_t Dim)(Cycle!(T, Dim) cycle, Slice!(T*, Dim) U
     foreach (i; 1 .. iter_cycle + 1)
     {
 
-        U = cycle.cycle(U);
+        cycle.cycle(U);
         auto norm = cycle.norm(U);
         logf("Residual has a L2-Norm of %f after %d iterations", norm, i);
         if (norm <= eps)

--- a/D/source/multid/multigrid/multigrid.d
+++ b/D/source/multid/multigrid/multigrid.d
@@ -42,9 +42,17 @@ Params:
 
 Returns: U
 +/
-Slice!(T*, Dim) poisson_multigrid(uint v1, uint v2, T, size_t Dim)(
-        Slice!(T*, Dim) F, Slice!(T*, Dim) U, uint level, uint mu, size_t iter_cycles,
-        string sweep = "field", T eps = 1e-6, T h = 0)
+Slice!(T*, Dim) poisson_multigrid(T, size_t Dim)(
+        Slice!(T*, Dim) F,
+        Slice!(T*, Dim) U,
+        uint level,
+        uint mu,
+        uint v1,
+        uint v2,
+        size_t iter_cycles,
+        string sweep = "ndslice",
+        T eps = 1e-6,
+        T h = 0)
 {
     Cycle!(T, Dim) cycle;
     switch (sweep)
@@ -55,8 +63,11 @@ Slice!(T*, Dim) poisson_multigrid(uint v1, uint v2, T, size_t Dim)(
     case "naive":
         cycle = new PoissonCycle!(T, Dim, SweepType.naive)(F, mu, level, h, v1, v2);
         break;
-    default:
+    case "field":
         cycle = new PoissonCycle!(T, Dim, SweepType.field)(F, mu, level, h, v1, v2);
+        break;
+    default:
+        cycle = new PoissonCycle!(T, Dim, SweepType.ndslice)(F, mu, level, h, v1, v2);
     }
     return multigrid!(T, Dim)(cycle, U, iter_cycles, eps);
 }
@@ -87,7 +98,7 @@ unittest
     F[$ - 1][1 .. $] = 0.0;
     F[1 .. $, $ - 1] = 0.0;
     auto U1 = U.dup;
-    poisson_multigrid!(2, 2)(F, U, 0, 2, 100, "field", 1e-9);
+    poisson_multigrid(F, U, 0, 2, 2, 2, 100, "field", 1e-9);
 
     GS_RB(F, U1, h);
 

--- a/D/source/multid/multigrid/multigrid.d
+++ b/D/source/multid/multigrid/multigrid.d
@@ -42,7 +42,7 @@ Params:
 
 Returns: U
 +/
-Slice!(T*, Dim) poisson_multigrid(T, size_t Dim, uint v1, uint v2)(
+Slice!(T*, Dim) poisson_multigrid(uint v1, uint v2, T, size_t Dim)(
         Slice!(T*, Dim) F, Slice!(T*, Dim) U, uint level, uint mu, size_t iter_cycles,
         string sweep = "field", T eps = 1e-6, T h = 0)
 {
@@ -87,9 +87,9 @@ unittest
     F[$ - 1][1 .. $] = 0.0;
     F[1 .. $, $ - 1] = 0.0;
     auto U1 = U.dup;
-    poisson_multigrid!(double, 2, 2, 2)(F, U, 0, 2, 100, "field", 1e-9);
+    poisson_multigrid!(2, 2)(F, U, 0, 2, 100, "field", 1e-9);
 
-    GS_RB!(double, 2)(F, U1, h);
+    GS_RB(F, U1, h);
 
     import numir : approxEqual;
 

--- a/D/source/multid/multigrid/multigrid.d
+++ b/D/source/multid/multigrid/multigrid.d
@@ -50,13 +50,13 @@ Slice!(T*, Dim) poisson_multigrid(uint v1, uint v2, T, size_t Dim)(
     switch (sweep)
     {
     case "slice":
-        cycle = new PoissonCycle!(T, Dim, v1, v2, SweepType.slice)(F, mu, level, h);
+        cycle = new PoissonCycle!(T, Dim, SweepType.slice)(F, mu, level, h, v1, v2);
         break;
     case "naive":
-        cycle = new PoissonCycle!(T, Dim, v1, v2, SweepType.naive)(F, mu, level, h);
+        cycle = new PoissonCycle!(T, Dim, SweepType.naive)(F, mu, level, h, v1, v2);
         break;
     default:
-        cycle = new PoissonCycle!(T, Dim, v1, v2, SweepType.field)(F, mu, level, h);
+        cycle = new PoissonCycle!(T, Dim, SweepType.field)(F, mu, level, h, v1, v2);
     }
     return multigrid!(T, Dim)(cycle, U, iter_cycles, eps);
 }

--- a/D/source/multid/multigrid/multigrid.d
+++ b/D/source/multid/multigrid/multigrid.d
@@ -12,7 +12,7 @@ Method to run some multigrid steps for abstract cycle
 Slice!(T*, Dim) multigrid(T, size_t Dim)(Cycle!(T, Dim) cycle, Slice!(T*, Dim) U, size_t iter_cycle, double eps)
 {
     //scale the epsilon with the number of gridpoints
-    eps *= U.shape[0] * U.shape[0];
+    eps *= U.elementCount;
     foreach (i; 1 .. iter_cycle + 1)
     {
 

--- a/D/source/multid/multigrid/prolongation.d
+++ b/D/source/multid/multigrid/prolongation.d
@@ -427,16 +427,16 @@ unittest
     auto ret6 = prolongation!(double, 2)(A, [6, 6]);
     auto ret7 = prolongation!(double, 2)(A, [7, 7]);
 
-    assert(ret6[0, 0 .. $].strided!(0)(2) == A[0, 0 .. $ - 1]);
-    assert(ret6[0 .. $, 0].strided!(0)(2) == A[0 .. $ - 1, 0]);
-    assert(ret6[$ - 2 .. $, 0 .. $].strided!(0, 1)(1, 2) == A[$ - 2 .. $, 0 .. $ - 1]);
-    assert(ret6[0 .. $, $ - 2 .. $].strided!(0)(2) == A[0 .. $ - 1, $ - 2 .. $]);
+    assert(ret6[0, 0 .. $].strided(2) == A[0, 0 .. $ - 1]);
+    assert(ret6[0 .. $, 0].strided(2) == A[0 .. $ - 1, 0]);
+    assert(ret6[$ - 2 .. $, 0 .. $].strided!1(2) == A[$ - 2 .. $, 0 .. $ - 1]);
+    assert(ret6[0 .. $, $ - 2 .. $].strided!0(2) == A[0 .. $ - 1, $ - 2 .. $]);
     assert(ret6[$ - 2 .. $, $ - 2 .. $] == A[$ - 2 .. $, $ - 2 .. $]);
 
-    assert(ret7[0, 0 .. $].strided!(0)(2) == A[0, 0 .. $]);
-    assert(ret7[0 .. $, 0].strided!(0)(2) == A[0 .. $, 0]);
-    assert(ret7[$ - 1 .. $, 0 .. $].strided!(1)(2) == A[$ - 1 .. $, 0 .. $]);
-    assert(ret7[0 .. $, $ - 1 .. $].strided!(0)(2) == A[0 .. $, $ - 1 .. $]);
+    assert(ret7[0, 0 .. $].strided(2) == A[0, 0 .. $]);
+    assert(ret7[0 .. $, 0].strided(2) == A[0 .. $, 0]);
+    assert(ret7[$ - 1 .. $, 0 .. $].strided!1(2) == A[$ - 1 .. $, 0 .. $]);
+    assert(ret7[0 .. $, $ - 1 .. $].strided!0(2) == A[0 .. $, $ - 1 .. $]);
 }
 
 unittest

--- a/D/source/multid/multigrid/prolongation.d
+++ b/D/source/multid/multigrid/prolongation.d
@@ -1,5 +1,6 @@
 module multid.multigrid.prolongation;
 
+import mir.math: fastmath;
 import mir.ndslice : slice, Slice;
 import numir : approxEqual;
 
@@ -10,8 +11,10 @@ This is the implementation of a prolongation
         fine_shape = the shape of the returned grid
     Returns: the finer grid with interpolated values in between
 +/
-Slice!(T*, Dim) prolongation(T, size_t Dim)(in Slice!(T*, Dim) e, in size_t[Dim] fine_shape)
+@fastmath
+Slice!(T*, Dim) prolongation(T, size_t Dim)(Slice!(const(T)*, Dim) e, const size_t[Dim] fine_shape)
 {
+    pragma(inline, false);
     auto w = slice!T(fine_shape);
     immutable end = e.shape[0] - (fine_shape[0] + 1) % 2;
     auto WF = w.field;

--- a/D/source/multid/multigrid/prolongation.d
+++ b/D/source/multid/multigrid/prolongation.d
@@ -37,7 +37,8 @@ void prolongation(IteratorA, IteratorB, size_t N, SliceKind aKind, SliceKind bKi
     import mir.functional: reverseArgs;
     import multid.multigrid.restriction;
     restriction!(reverseArgs!expand)(b.byDim!0, a.byDim!0);
-    each!apply(a.byDim!0.slide!(3, "a + c").stride, a.byDim!0[1 .. $ - 1].stride);
+    // use `.retro` to be more CPU-cache friendly
+    each!apply(a.byDim!0.slide!(3, "a + c").stride.retro, a.byDim!0[1 .. $ - 1].stride.retro);
 }
 
 // Tests 1D

--- a/D/source/multid/multigrid/prolongation.d
+++ b/D/source/multid/multigrid/prolongation.d
@@ -15,14 +15,16 @@ This is the implementation of a prolongation
 Slice!(T*, Dim) prolongation(T, size_t Dim)(Slice!(const(T)*, Dim) e, size_t[Dim] fine_shape)
 {
     auto w = slice!T(fine_shape);
-    prolongation(e, w);
+    prolongation(w, e);
     return w;
 }
 
 @nogc @fastmath
-void prolongation(T, size_t Dim)(Slice!(const(T)*, Dim) e, Slice!(T*, Dim) w)
+void prolongation(T, size_t Dim)(Slice!(T*, Dim) w, Slice!(const(T)*, Dim) e)
 {
     pragma(inline, false);
+    import std.conv;
+    assert(w.length / 2 + 1 == e.length);
     immutable end = e.shape[0] - (w.shape[0] + 1) % 2;
     auto WF = w.field;
     auto EF = e.field;

--- a/D/source/multid/multigrid/prolongation.d
+++ b/D/source/multid/multigrid/prolongation.d
@@ -37,8 +37,7 @@ void prolongation(IteratorA, IteratorB, size_t N, SliceKind aKind, SliceKind bKi
     import mir.functional: reverseArgs;
     import multid.multigrid.restriction;
     restriction!(reverseArgs!expand)(b.byDim!0, a.byDim!0);
-    // use `.retro` to be more CPU-cache friendly
-    each!apply(a.byDim!0.slide!(3, "a + c").stride.retro, a.byDim!0[1 .. $ - 1].stride.retro);
+    each!apply(a.byDim!0.slide!(3, "a + c").stride, a.byDim!0[1 .. $ - 1].stride);
 }
 
 // Tests 1D

--- a/D/source/multid/multigrid/prolongation.d
+++ b/D/source/multid/multigrid/prolongation.d
@@ -37,7 +37,7 @@ void prolongation(IteratorA, IteratorB, size_t N, SliceKind aKind, SliceKind bKi
     import mir.functional: reverseArgs;
     import multid.multigrid.restriction;
     restriction!(reverseArgs!expand)(b.byDim!0, a.byDim!0);
-    each!apply(a.byDim!0.slide!(3, "a + c").strided(2), a.byDim!0[1 .. $ - 1].strided(2));
+    each!apply(a.byDim!0.slide!(3, "a + c").stride, a.byDim!0[1 .. $ - 1].stride);
 }
 
 // Tests 1D
@@ -132,14 +132,14 @@ unittest
     auto ret6 = prolongation!(double, 2)(A, [6, 6]);
     auto ret7 = prolongation!(double, 2)(A, [7, 7]);
 
-    assert(ret6[0, 0 .. $].strided(2) == A[0, 0 .. $ - 1]);
-    assert(ret6[0 .. $, 0].strided(2) == A[0 .. $ - 1, 0]);
+    assert(ret6[0, 0 .. $].stride == A[0, 0 .. $ - 1]);
+    assert(ret6[0 .. $, 0].stride == A[0 .. $ - 1, 0]);
     assert(ret6[$ - 2 .. $, 0 .. $].strided!1(2) == A[$ - 2 .. $, 0 .. $ - 1]);
     assert(ret6[0 .. $, $ - 2 .. $].strided!0(2) == A[0 .. $ - 1, $ - 2 .. $]);
     assert(ret6[$ - 2 .. $, $ - 2 .. $] == A[$ - 2 .. $, $ - 2 .. $]);
 
-    assert(ret7[0, 0 .. $].strided(2) == A[0, 0 .. $]);
-    assert(ret7[0 .. $, 0].strided(2) == A[0 .. $, 0]);
+    assert(ret7[0, 0 .. $].stride == A[0, 0 .. $]);
+    assert(ret7[0 .. $, 0].stride == A[0 .. $, 0]);
     assert(ret7[$ - 1 .. $, 0 .. $].strided!1(2) == A[$ - 1 .. $, 0 .. $]);
     assert(ret7[0 .. $, $ - 1 .. $].strided!0(2) == A[0 .. $, $ - 1 .. $]);
 }

--- a/D/source/multid/multigrid/restriction.d
+++ b/D/source/multid/multigrid/restriction.d
@@ -97,13 +97,13 @@ void restriction(T, size_t Dim : 3)(Slice!(T*, Dim) ret, Slice!(const(T)*, Dim) 
         }
     }
     // special case: inner borders
-    ret[0 .. end, 0 .. end, $ - 1] = A[0 .. $, 0 .. $, $ - 1].strided!(0, 1)(2, 2);
-    ret[$ - 1, 0 .. end, 0 .. end] = A[$ - 1, 0 .. $, 0 .. $].strided!(0, 1)(2, 2);
-    ret[0 .. end, $ - 1, 0 .. end] = A[0 .. $, $ - 1, 0 .. $].strided!(0, 1)(2, 2);
+    ret[0 .. end, 0 .. end, $ - 1] = A[0 .. $, 0 .. $, $ - 1].strided(2);
+    ret[$ - 1, 0 .. end, 0 .. end] = A[$ - 1, 0 .. $, 0 .. $].strided(2);
+    ret[0 .. end, $ - 1, 0 .. end] = A[0 .. $, $ - 1, 0 .. $].strided(2);
     // special case: outer borders
-    ret[0 .. end, $ - 1, $ - 1] = A[0 .. $, $ - 1, $ - 1].strided!(0)(2);
-    ret[$ - 1, 0 .. end, $ - 1] = A[$ - 1, 0 .. $, $ - 1].strided!(0)(2);
-    ret[$ - 1, $ - 1, 0 .. end] = A[$ - 1, $ - 1, 0 .. $].strided!(0)(2);
+    ret[0 .. end, $ - 1, $ - 1] = A[0 .. $, $ - 1, $ - 1].strided(2);
+    ret[$ - 1, 0 .. end, $ - 1] = A[$ - 1, 0 .. $, $ - 1].strided(2);
+    ret[$ - 1, $ - 1, 0 .. end] = A[$ - 1, $ - 1, 0 .. $].strided(2);
     // special case: outer corner
     ret.field[$ - 1] = AF[$ - 1];
 }

--- a/D/source/multid/multigrid/restriction.d
+++ b/D/source/multid/multigrid/restriction.d
@@ -70,8 +70,7 @@ void weighted_restriction(T, size_t N)(Slice!(T*, N) r, Slice!(const(T)*, N) A)
     else
         alias scaled = a => a * (T(1) / factor);
 
-    // use `.retro` to be more CPU-cache friendly
-    rc.retro[] = ac.slide!(3, "a + 2 * b + c").map!scaled.strided(2).retro;
+    rc[] = ac.slide!(3, "a + 2 * b + c").map!scaled.strided(2);
 }
 
 

--- a/D/source/multid/multigrid/restriction.d
+++ b/D/source/multid/multigrid/restriction.d
@@ -70,7 +70,8 @@ void weighted_restriction(T, size_t N)(Slice!(T*, N) r, Slice!(const(T)*, N) A)
     else
         alias scaled = a => a * (T(1) / factor);
 
-    rc[] = ac.slide!(3, "a + 2 * b + c").map!scaled.strided(2);
+    // use `.retro` to be more CPU-cache friendly
+    rc.retro[] = ac.slide!(3, "a + 2 * b + c").map!scaled.strided(2).retro;
 }
 
 

--- a/D/source/multid/tools/apply_poisson.d
+++ b/D/source/multid/tools/apply_poisson.d
@@ -21,85 +21,9 @@ Slice!(T*, Dim) apply_poisson(T, size_t Dim)(Slice!(const(T)*, Dim) U, const T h
 @nogc @fastmath
 void apply_poisson(T, size_t Dim)(Slice!(T*, Dim) x, Slice!(const(T)*, Dim) U, const T h)
 {
-    assert(x.shape == U.shape);
-    const T h2 = h * h;
-    auto UF = U.field;
-
-    static if (Dim == 1)
-    {
-        x.field[0] = UF[0];
-        x.field[$ - 1] = UF[$ - 1];
-        foreach (i; 1 .. U.shape[0] - 1)
-        {
-            x.field[i] = (-2.0 * UF[i] + UF[i - 1] + UF[i + 1]) / h2;
-        }
-
-    }
-    else static if (Dim == 2)
-    {
-        immutable m = U.shape[0];
-        immutable n = U.shape[1];
-
-        x.field[0 .. m] = UF[0 .. m];
-        x.field[$ - m .. $] = UF[$ - m .. $];
-
-        x[1 .. $ - 1, 0] = U[1 .. $ - 1, 0];
-        x[1 .. $ - 1, $ - 1] = U[1 .. $ - 1, $ - 1];
-
-        foreach (i; 1 .. m - 1)
-        {
-            foreach (j; 1 .. n - 1)
-            {
-                auto flatindex = i * m + j;
-                x.field[flatindex] = (
-                        -4.0 * UF[flatindex] +
-                        UF[flatindex - m] +
-                        UF[flatindex + m] +
-                        UF[flatindex - 1] +
-                        UF[flatindex + 1]) / h2;
-            }
-        }
-    }
-    else static if (Dim == 3)
-    {
-
-        const auto m = U.shape[0];
-        const auto n = U.shape[1];
-        const auto l = U.shape[2];
-
-        x[0 .. $, 0 .. $, 0] = U[0 .. $, 0 .. $, 0];
-        x[0 .. $, 0, 0 .. $] = U[0 .. $, 0, 0 .. $];
-        x[0, 0 .. $, 0 .. $] = U[0, 0 .. $, 0 .. $];
-
-        x[0 .. $, 0 .. $, $ - 1] = U[0 .. $, 0 .. $, $ - 1];
-        x[0 .. $, $ - 1, 0 .. $] = U[0 .. $, $ - 1, 0 .. $];
-        x[$ - 1, 0 .. $, 0 .. $] = U[$ - 1, 0 .. $, 0 .. $];
-
-        for (size_t i = 1; i < m - 1; i++)
-        {
-            for (size_t j = 1; j < n - 1; j++)
-            {
-                const auto flatindex2d = i * (n * l) + j * l;
-                for (size_t k = 1; k < l - 1; k++)
-                {
-                    const flatindex = flatindex2d + k;
-                    x.field[flatindex] = (
-                            -6.0 *
-                            UF[flatindex] +
-                            UF[flatindex - n * l] +
-                            UF[flatindex + n * l] +
-                            UF[flatindex - l] +
-                            UF[flatindex + l] +
-                            UF[flatindex - 1] +
-                            UF[flatindex + 1]) / h2;
-                }
-            }
-        }
-    }
-    else
-    {
-        static assert(false, Dim.stringof ~ " is not a supported dimension!");
-    }
+    assumeSameShape(x, U);
+    eachOnBorder!"a = b"(x, U);
+    x.dropBorders[] = (1 / (h * h)) * U.withNeighboursSum.map!((u, sum) => sum - 2 * Dim * u);
 }
 
 /++
@@ -108,10 +32,13 @@ void apply_poisson(T, size_t Dim)(Slice!(T*, Dim) x, Slice!(const(T)*, Dim) U, c
 @nogc @fastmath
 void compute_residual(T, size_t Dim)(Slice!(T*, Dim) R, Slice!(const(T)*, Dim) F, Slice!(const(T)*, Dim) U, const T current_h)
 {
-    assert(U.shape == F.shape);
-    assert(R.shape == F.shape);
-    apply_poisson(R, U, current_h);
-    R.field[] = F.field[] - R.field[];
+    assumeSameShape(U, R, F);
+    // performs
+    // apply_poisson(R, U, current_h);
+    // R[] = F - R
+    // in a single memory access
+    R.dropBorders[] = ((1 / current_h ^^ 2) * U.withNeighboursSum.map!((u, sum) => sum - 2 * Dim * u)).zip!true(F.dropBorders).map!"b - a";
+    eachOnBorder!"a = b - c"(R.retro, F.retro, U.retro); // retro: be a CPU cache friendly
 }
 
 Slice!(T*, Dim) compute_residual(T, size_t Dim)(Slice!(const(T)*, Dim) F, Slice!(const(T)*, Dim) U, const T current_h)
@@ -124,12 +51,14 @@ Slice!(T*, Dim) compute_residual(T, size_t Dim)(Slice!(const(T)*, Dim) F, Slice!
 
 unittest
 {
+    import mir.algorithm.iteration: all;
+    import mir.math.common: approxEqual;
     import multid.tools.util : randomMatrix;
 
     const size_t N = 100;
     immutable auto h = 1.0 / double(N);
 
-    auto U = randomMatrix!(double, 1)(N);
+    auto U = N.randomMatrix!(double, 1);
 
     auto x = U.dup;
     for (size_t i = 1; i < U.shape[0] - 1; i++)
@@ -137,19 +66,20 @@ unittest
         x[i] = (-2.0 * U[i] + U[i - 1] + U[i + 1]) / (h * h);
     }
 
-    const auto x1 = apply_poisson!(double, 1)(U, h);
-    assert(x == x1);
+    auto x1 = apply_poisson(U, h);
+    assert(all!approxEqual(x, x1));
 }
 
 unittest
 {
-
+    import mir.algorithm.iteration: all;
+    import mir.math.common: approxEqual;
     import multid.tools.util : randomMatrix;
 
     const size_t N = 100;
     immutable auto h = 1.0 / double(N);
 
-    auto U = randomMatrix!(double, 2)(N);
+    auto U = N.randomMatrix!(double, 2);
 
     immutable m = U.shape[0];
     immutable n = U.shape[1];
@@ -159,23 +89,29 @@ unittest
     {
         for (size_t j = 1; j < n - 1; j++)
         {
-            x[i, j] = (-4.0 * U[i, j] + U[i - 1, j] + U[i + 1, j] + U[i, j - 1]
-                    + U[i, j + 1]) / (h * h);
+            x[i, j] = (-4.0 * U[i, j]
+                + U[i - 1, j]
+                + U[i + 1, j]
+                + U[i, j - 1]
+                + U[i, j + 1]) / (h * h);
         }
     }
-    const auto x1 = apply_poisson!(double, 2)(U, h);
-    assert(x == x1);
+
+    auto x1 = apply_poisson(U, h);
+    assert(all!approxEqual(x, x1));
 }
 
 
 unittest
 {
+    import mir.algorithm.iteration: all;
+    import mir.math.common: approxEqual;
     import multid.tools.util : randomMatrix;
 
     const size_t N = 100;
     immutable auto h = 1.0 / double(N);
 
-    auto U = randomMatrix!(double, 3)(N);
+    auto U = N.randomMatrix!(double, 3);
 
     auto x = U.dup;
     for (size_t i = 1; i < U.shape[0] - 1; i++)
@@ -196,7 +132,6 @@ unittest
         }
     }
 
-    const auto x1 = apply_poisson!(double, 3)(U, h);
-
-    assert(x == x1);
+    auto x1 = apply_poisson(U, h);
+    assert(all!approxEqual(x, x1));
 }

--- a/D/source/multid/tools/apply_poisson.d
+++ b/D/source/multid/tools/apply_poisson.d
@@ -38,7 +38,7 @@ void compute_residual(T, size_t Dim)(Slice!(T*, Dim) R, Slice!(const(T)*, Dim) F
     // R[] = F - R
     // in a single memory access
     R.dropBorders[] = ((1 / current_h ^^ 2) * U.withNeighboursSum.map!((u, sum) => sum - 2 * Dim * u)).zip!true(F.dropBorders).map!"b - a";
-    eachOnBorder!"a = b - c"(R.retro, F.retro, U.retro); // retro: be more CPU cache friendly
+    eachOnBorder!"a = b - c"(R, F, U);
 }
 
 Slice!(T*, Dim) compute_residual(T, size_t Dim)(Slice!(const(T)*, Dim) F, Slice!(const(T)*, Dim) U, const T current_h)

--- a/D/source/multid/tools/apply_poisson.d
+++ b/D/source/multid/tools/apply_poisson.d
@@ -10,7 +10,7 @@ import mir.ndslice;
         h = distance between grid points
     Returns: x = A*U
 +/
-Slice!(T*, Dim) apply_poisson(T, size_t Dim)(in Slice!(T*, Dim) U, in T h)
+Slice!(T*, Dim) apply_poisson(T, size_t Dim)(Slice!(const(T)*, Dim) U, const T h)
 {
     auto x = slice!(T)(U.shape);
     const T h2 = h * h;
@@ -98,7 +98,7 @@ Slice!(T*, Dim) apply_poisson(T, size_t Dim)(in Slice!(T*, Dim) U, in T h)
 /++
     Computes F - AU were A is the poisson matrix
 +/
-Slice!(T*, Dim) compute_residual(T, size_t Dim)(in Slice!(T*, Dim) F, in Slice!(T*, Dim) U, in T current_h)
+Slice!(T*, Dim) compute_residual(T, size_t Dim)(Slice!(const(T)*, Dim) F, Slice!(const(T)*, Dim) U, const T current_h)
 {
     auto AU = apply_poisson!(T, Dim)(U, current_h);
     AU.field[] = F.field[] - AU.field[];

--- a/D/source/multid/tools/apply_poisson.d
+++ b/D/source/multid/tools/apply_poisson.d
@@ -38,7 +38,7 @@ void compute_residual(T, size_t Dim)(Slice!(T*, Dim) R, Slice!(const(T)*, Dim) F
     // R[] = F - R
     // in a single memory access
     R.dropBorders[] = ((1 / current_h ^^ 2) * U.withNeighboursSum.map!((u, sum) => sum - 2 * Dim * u)).zip!true(F.dropBorders).map!"b - a";
-    eachOnBorder!"a = b - c"(R.retro, F.retro, U.retro); // retro: be a CPU cache friendly
+    eachOnBorder!"a = b - c"(R.retro, F.retro, U.retro); // retro: be more CPU cache friendly
 }
 
 Slice!(T*, Dim) compute_residual(T, size_t Dim)(Slice!(const(T)*, Dim) F, Slice!(const(T)*, Dim) U, const T current_h)

--- a/D/source/multid/tools/norm.d
+++ b/D/source/multid/tools/norm.d
@@ -1,11 +1,12 @@
 module multid.tools.norm;
 
-import std.math : sqrt;
+import mir.math : sqrt, fastmath;
 import mir.ndslice : Slice, sliced;
 
 /++
     Computes the L2 norm
 +/
+@fastmath
 T nrmL2(T, size_t Dim)(Slice!(T*, Dim) v)
 {
     T s = 0.0;

--- a/D/source/multid/tools/util.d
+++ b/D/source/multid/tools/util.d
@@ -1,8 +1,6 @@
 module multid.tools.util;
-import mir.ndslice : Slice, slice;
-import std.range : generate;
-import std.random : uniform;
-import std.algorithm : fill;
+
+import mir.ndslice.slice: Slice;
 
 /++ Timer Template +/
 template Timer()
@@ -28,8 +26,9 @@ template Timer()
 /++ Generator for random matrix with dimension Dim and dimension size N +/
 Slice!(T*, Dim) randomMatrix(T, size_t Dim)(size_t N)
 {
+    import mir.random.algorithm: randomSlice;
+    import mir.random.variable: uniformVar;
+
     size_t[Dim] shape = N;
-    auto ret = slice!T(shape);
-    ret.field.fill(generate!(() => uniform(0.0, 1.0)));
-    return ret;
+    return uniformVar!T(0, 1).randomSlice(shape);
 }

--- a/D/source/scripts.d
+++ b/D/source/scripts.d
@@ -1,18 +1,13 @@
-import std.stdio;
-import std.range : generate;
-import std.random : uniform;
-import std.array;
-import std.algorithm;
+import loadproblem;
 import mir.ndslice;
-import pretty_array;
-import std.datetime.stopwatch : StopWatch;
-import std.conv : to;
-
 import multid.gaussseidel.redblack;
-import multid.multigrid.restriction;
 import multid.multigrid.cycle;
 import multid.multigrid.multigrid;
-import loadproblem;
+import multid.multigrid.restriction;
+import multid.tools.util;
+import pretty_array;
+import std.datetime.stopwatch : StopWatch;
+import std.stdio;
 
 /++
 This performs a GS_RB run for 3D
@@ -21,9 +16,7 @@ void test3D()
 {
 
     immutable size_t N = 50;
-    auto U = slice!double(N, N, N);
-    auto fun = generate!(() => uniform(0.0, 1.0));
-    U.field.fill(fun);
+    auto U = N.randomMatrix!(double, 3);
     U[0, 0 .. $, 0 .. $] = 1.0;
     U[0 .. $, 0, 0 .. $] = 1.0;
     U[0 .. $, 0 .. $, 0] = 1.0;
@@ -34,7 +27,7 @@ void test3D()
     auto F = slice!double([N, N, N], 0.0);
     const double h = 1.0 / double(N);
 
-    GS_RB!(double, 3)(F, U, h);
+    GS_RB(F, U, h);
     U.prettyArr.writeln;
 
 }
@@ -46,9 +39,7 @@ void test2D()
 {
 
     immutable size_t N = 200;
-    auto U = slice!double(N, N);
-    auto fun = generate!(() => uniform(0.0, 1.0));
-    U.field.fill(fun);
+    auto U = N.randomMatrix!(double, 2);
     U[0][0 .. $] = 1.0;
     U[1 .. $, 0] = 1.0;
     U[$ - 1][1 .. $] = 0.0;
@@ -57,7 +48,7 @@ void test2D()
     auto F = slice!double([N, N], 0.0);
     const double h = 1.0 / double(N);
 
-    GS_RB!(double, 2)(F, U, h);
+    GS_RB(F, U, h);
     U.prettyArr.writeln;
 
 }
@@ -69,16 +60,14 @@ void test1D()
 {
 
     immutable size_t N = 1000;
-    auto U = slice!double(N);
-    auto fun = generate!(() => uniform(0.0, 1.0));
-    U.field.fill(fun);
+    auto U = N.randomMatrix!(double, 1);
     U[0] = 1.0;
     U[$ - 1] = 0.0;
 
     auto F = slice!double([N], 0.0);
     const double h = 1.0 / double(N);
 
-    GS_RB!(double, 1, 30_000)(F, U, h);
+    GS_RB!(30_000)(F, U, h);
     U.prettyArr.writeln;
 
 }
@@ -89,9 +78,7 @@ This performs multigrid for 2D
 void testMG2D()
 {
     immutable size_t N = 1000;
-    auto U = slice!double(N, N);
-    auto fun = generate!(() => uniform(0.0, 1.0));
-    U.field.fill(fun);
+    auto U = N.randomMatrix!(double, 2);
     U[0][0 .. $] = 1.0;
     U[1 .. $, 0] = 1.0;
     U[$ - 1][1 .. $] = 0.0;
@@ -103,7 +90,7 @@ void testMG2D()
     F[$ - 1][1 .. $] = 0.0;
     F[1 .. $, $ - 1] = 0.0;
 
-    U = poisson_multigrid!(double, 2, 2, 2)(F, U, 0, 2, 100);
+    U = poisson_multigrid!(2, 2)(F, U, 0, 2, 100);
 
     //U.prettyArr.writeln;
 }

--- a/D/source/scripts.d
+++ b/D/source/scripts.d
@@ -67,7 +67,7 @@ void test1D()
     auto F = slice!double([N], 0.0);
     const double h = 1.0 / double(N);
 
-    GS_RB!(30_000)(F, U, h);
+    GS_RB(F, U, h, 30_000);
     // U.prettyArr.writeln;
 
 }

--- a/D/source/scripts.d
+++ b/D/source/scripts.d
@@ -5,7 +5,7 @@ import multid.multigrid.cycle;
 import multid.multigrid.multigrid;
 import multid.multigrid.restriction;
 import multid.tools.util;
-import pretty_array;
+// import pretty_array;
 import std.datetime.stopwatch : StopWatch;
 import std.stdio;
 
@@ -28,7 +28,7 @@ void test3D()
     const double h = 1.0 / double(N);
 
     GS_RB(F, U, h);
-    U.prettyArr.writeln;
+    // U.prettyArr.writeln;
 
 }
 
@@ -49,7 +49,7 @@ void test2D()
     const double h = 1.0 / double(N);
 
     GS_RB(F, U, h);
-    U.prettyArr.writeln;
+    // U.prettyArr.writeln;
 
 }
 
@@ -68,7 +68,7 @@ void test1D()
     const double h = 1.0 / double(N);
 
     GS_RB!(30_000)(F, U, h);
-    U.prettyArr.writeln;
+    // U.prettyArr.writeln;
 
 }
 

--- a/D/source/scripts.d
+++ b/D/source/scripts.d
@@ -90,7 +90,7 @@ void testMG2D()
     F[$ - 1][1 .. $] = 0.0;
     F[1 .. $, $ - 1] = 0.0;
 
-    U = poisson_multigrid!(2, 2)(F, U, 0, 2, 100);
+    U = poisson_multigrid(F, U, 0, 2, 2, 2, 100);
 
     //U.prettyArr.writeln;
 }

--- a/D/source/startup.d
+++ b/D/source/startup.d
@@ -14,7 +14,7 @@ template init()
     uint delay = 500;
     bool verbose = false;
     string path = default_path;
-    string sweep = "field";
+    string sweep = "ndslice";
     immutable string default_path = "../problems/problem_2D_100.npy";
 
     void start()

--- a/D/source/startup.d
+++ b/D/source/startup.d
@@ -3,12 +3,11 @@ module startup;
 
 template init()
 {
-
     import core.thread : Thread;
+    import mir.conv : to;
     import std.datetime.stopwatch : StopWatch, msecs;
     import std.experimental.logger : infof, globalLogLevel, LogLevel;
     import std.getopt : getopt;
-    import std.conv : to;
 
     StopWatch sw;
 


### PR DESCRIPTION
Changelog:
1. Reworked `sweep_slice` to access memory only once like the Python code. I didn't make a benchmark, but I expect it will be a few times faster now.
2. Added `fastmath` to the kernel-like API and `pragma(inline, false)` for some API. The last one is required to make the first one work well.
3. Changed `/` with `*` where possible (it is fine for this kind of numeric code).
4. Used more `mir.*` alternatives if possible.
5. Simplified API for some functions
6. ndslice-like rework for restriction
7. ndslice-like rework for prolongation
8. @nogc cycle
